### PR TITLE
Adjust backgrounds and borders for readonly input and textarea

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -38,10 +38,9 @@
 }
 
 .md-input.md-input--readonly:not(.md-input.md-input--disabled) {
-  border-left-color: #fff;
-  border-right-color: #fff;
-  border-top-color: #fff;
   background-color: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--mdGreyColor60);
 }
 
 .md-input.md-input--error {

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -45,6 +45,7 @@
 .md-select--disabled .md-select__button {
   background-color: var(--mdGreyColor20);
   color: var(--mdGreyColor60);
+  cursor: not-allowed;
 }
 
 .md-select__button:focus,

--- a/packages/css/src/formElements/textarea/textarea.css
+++ b/packages/css/src/formElements/textarea/textarea.css
@@ -35,7 +35,7 @@
 }
 
 .md-textarea.md-textarea--readonly:not(.md-textarea.md-textarea--disabled) {
-  border-color: #fff;
+  border: 0;
   background-color: transparent;
 }
 


### PR DESCRIPTION
Adjust backgrounds and borders for readonly input and textarea
Add not-allowed-cursor to MdSelect when disabled

## Describe your changes
Remove borders for readonly input- and textareafields. Adjust backgrounds, and add not-allowed-cursor to MdSelect when disabled.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

