### PR TITLE
Remove useMemo from id generattion

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -7,7 +7,7 @@ import MdMinusIcon from '../icons/MdMinusIcon';
 interface MdAccordionItemProps {
   label?: string;
   headerContent?: React.ReactNode | string;
-  id?: string | number;
+  id?: string | number | null | undefined;
   expanded?: boolean;
   theme?: string;
   disabled?: boolean;
@@ -21,7 +21,7 @@ interface MdAccordionItemProps {
 const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
   label = '',
   headerContent,
-  id,
+  id = null,
   expanded = false,
   theme,
   disabled = false,
@@ -31,7 +31,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
   rounded = false,
   onToggle
 }: MdAccordionItemProps) => {
-  const accordionId = React.useMemo(() => id || uuidv4(), []);
+  const accordionId = id || uuidv4();
   const [isExpanded, setExpanded] = useState(false);
 
   React.useEffect(() => {

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -42,7 +42,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
   onBlur,
   ...otherProps
 }: MdCheckboxGroupProps) => {
-  const groupId = React.useMemo(() => id || uuidv4(), []);
+  const groupId = id || uuidv4();
   const [helpOpen, setHelpOpen] = useState(false);
 
   const classNames = classnames(

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -46,7 +46,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   id,
   ...otherProps
 }: MdMultiSelectProps) => {
-  const uuid = React.useMemo(() => id || uuidv4(), []);
+  const uuid = id || uuidv4();
   const [open, setOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 

--- a/packages/react/src/formElements/MdRadioGroup.tsx
+++ b/packages/react/src/formElements/MdRadioGroup.tsx
@@ -41,7 +41,7 @@ const MdRadioGroup: React.FunctionComponent<MdRadioGroupProps> = ({
   onBlur,
   ...otherProps
 }: MdRadioGroupProps) => {
-  const radioId = React.useMemo(() => id || uuidv4(), []);
+  const radioId = id || uuidv4();
   const [helpOpen, setHelpOpen] = useState(false);
 
   const classNames = classnames(

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -16,6 +16,7 @@ interface MdSelectOptionProps {
 export interface MdSelectProps {
     label?: string | null;
     options?: MdSelectOptionProps[];
+    id?: string | number | null | undefined;
     onChange(e: MdSelectOptionProps): void;
     name?: string;
     value?: string | number;
@@ -31,6 +32,7 @@ const MdSelect: React.FunctionComponent<MdSelectProps> = ({
   label,
   value,
   options,
+  id = null,
   name,
   placeholder = 'Vennligst velg',
   disabled = false,
@@ -44,7 +46,7 @@ const MdSelect: React.FunctionComponent<MdSelectProps> = ({
   const [open, setOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 
-  const uuid = React.useMemo(() => uuidv4(), []);
+  const uuid = id || uuidv4();
 
   const classNames = classnames('md-select', {
     'md-select--open': !!open,

--- a/stories/AccordionStories/AccordionItem.stories.tsx
+++ b/stories/AccordionStories/AccordionItem.stories.tsx
@@ -48,6 +48,17 @@ export default {
       },
       control: { type: 'text' }
     },
+    id: {
+      type: { name: 'string | number' },
+      description: "The id for the accordion item.",
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: "string",
+        },
+      },
+      control: { type: 'text' }
+    },
     theme: {
       type: { name: 'string' },
       description: "Color theme for accordion.",
@@ -103,6 +114,15 @@ export default {
         },
       },
       control: { type: 'boolean' }
+    },
+    onToggle: {
+      type: { name: 'function' },
+      description: "Handler for controlling expand/collapse. If not present, component handles expand/collapse internally.",
+      table: {
+        type: {
+          summary: "function",
+        },
+      },
     }
   }
 };
@@ -125,6 +145,7 @@ const Template: ComponentStory<typeof MdAccordionItem> = (args) => {
 export const AccordionItem = Template.bind({});
 AccordionItem.args = {
   label: 'Click to toggle accordion item',
+  id: '',
   theme: 'primary',
   disabled: false,
   headerContent: false,

--- a/stories/ChipsStories/FilterChip.stories.tsx
+++ b/stories/ChipsStories/FilterChip.stories.tsx
@@ -88,10 +88,9 @@ export default {
       control: { type: 'boolean' }
     },
     onClick: {
-      type: { name: 'array', required: true },
+      type: { name: 'function', required: true },
       description: 'Callback for click handling.',
       table: {
-        defaultValue: { summary: 'function' },
         type: {
           summary: null,
         },

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -67,6 +67,17 @@ export default {
       },
       control: { type: 'text' }
     },
+    id: {
+      type: { name: 'string | number' },
+      description: "Id for the select box. If not set, uses a random uuid",
+      table: {
+        defaultValue: { summary: 'uuid()' },
+        type: {
+          summary: "string",
+        },
+      },
+      control: { type: 'text' }
+    },
     disabled: {
       table: {
         defaultValue: { summary: 'false' },
@@ -157,6 +168,7 @@ Select.args = {
     { value: 'option4', text: 'Option 4' }
   ],
   value: 'option2',
+  id: '',
   disabled: false,
   size: 'large',
   helpText: '',


### PR DESCRIPTION
add id as attribute to more components

## Describe your changes
useMemo caused components to get same id.
Added `id` as attribute to more components, so keys and ids can be customized

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

