### PR TITLE
MALIN-390 fix: z-index

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -158,6 +158,7 @@
   transition: max-height .5s ease-in-out;
   border: 2px solid var(--mdPrimaryColor);
   border-top: 0;
+  z-index: 2;
 }
 
 /* open + error */


### PR DESCRIPTION
## Describe your changes
Lagt til z-index på dropdownen slik at den legger seg over andre select knapper under

![image](https://github.com/miljodir/md-components/assets/21305389/422adb00-a6a3-4bdb-bbc8-43b313394dbe)


## Checklist before requesting a review
- [✅] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

