### PR TITLE
Remove auto-animate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@formkit/auto-animate": "^1.0.0-beta.5",
         "@types/node": "^18.11.17",
         "@types/react": "^18.0.26",
         "classnames": "^2.3.1"
@@ -2050,11 +2049,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@formkit/auto-animate": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-1.0.0-beta.5.tgz",
-      "integrity": "sha512-WoSwyhAZPOe6RB/IgicOtCHtrWwEpfKIZ/H/nxpKfnZL9CB6hhhBGU5bCdMRw7YpAUF2CDlQa+WWh+gCqz5lDg=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -19705,11 +19699,6 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
-    },
-    "@formkit/auto-animate": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-1.0.0-beta.5.tgz",
-      "integrity": "sha512-WoSwyhAZPOe6RB/IgicOtCHtrWwEpfKIZ/H/nxpKfnZL9CB6hhhBGU5bCdMRw7YpAUF2CDlQa+WWh+gCqz5lDg=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@formkit/auto-animate": "^1.0.0-beta.5",
     "@types/node": "^18.11.17",
     "@types/react": "^18.0.26",
     "classnames": "^2.3.1"

--- a/packages/css/src/infoTag/infoTag.css
+++ b/packages/css/src/infoTag/infoTag.css
@@ -27,10 +27,18 @@
 
 .md-info-tag__label {
   display: flex;
+  max-width: 0;
+  overflow: hidden;
   align-self: flex-start;
-  margin-right: 12px;
   font-size: 14px;
   line-height: 18px;
+}
+
+.md-info-tag__label--show {
+  max-width: 100%;
+  margin-right: 12px;
+  animation: width 0.3s ease-in 1 forwards;
+  white-space: nowrap;
 }
 
 .md-info-tag__icon {

--- a/packages/css/src/utils.css
+++ b/packages/css/src/utils.css
@@ -11,3 +11,12 @@
     transform: rotate(360deg);
   }
 }
+
+@keyframes width {
+  0% {
+    max-width: 0;
+  }
+  100% {
+    max-width: 100%;
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.1",
-    "uuid": "^8.3.2",
-    "@formkit/auto-animate": "^1.0.0-beta.5"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "typescript": "^4.7.3"

--- a/packages/react/src/infoTag/MdInfoTag.tsx
+++ b/packages/react/src/infoTag/MdInfoTag.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
-import autoAnimate from '@formkit/auto-animate';
+import React, { useState, useRef } from "react";
 import classnames from 'classnames';
 
 import MdInfoIcon from "../icons/MdInfoIcon";
@@ -27,14 +26,14 @@ const MdInfoTag: React.FC<MdInfoTagProps> = ({
   const [hover, setHover] = useState(false);
   const parent = useRef(null)
 
-  useEffect(() => {
-    parent.current && autoAnimate(parent.current)
-  }, [parent])
-
   const classNames = classnames('md-info-tag', {
     'md-info-tag--secondary': theme === 'secondary',
     'md-info-tag--warning': theme === 'warning',
     'md-info-tag--danger': theme === 'danger'
+  });
+
+  const labelClassNames = classnames('md-info-tag__label', {
+    'md-info-tag__label--show': hover || keepOpen
   });
 
   const renderIcon = () => {
@@ -60,9 +59,7 @@ const MdInfoTag: React.FC<MdInfoTagProps> = ({
       onMouseLeave={() => setHover(false)}
       ref={parent}
     >
-      {(hover || keepOpen) &&
-        <div className="md-info-tag__label">{label}</div>
-      }
+      <div className={labelClassNames}>{label}</div>
 
       <div className="md-info-tag__icon">
         {renderIcon()}

--- a/stories/Messages/AlertMessage.stories.tsx
+++ b/stories/Messages/AlertMessage.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
 import { ComponentStory } from "@storybook/react";
-import autoAnimate from "@formkit/auto-animate";
 import {
   Title,
   Subtitle,
@@ -84,10 +83,6 @@ export default {
 const Template: ComponentStory<typeof MdAlertMessage> = args => {
   const [show, setShow] = useState(true);
   const parent = useRef(null);
-
-  useEffect(() => {
-    parent.current && autoAnimate(parent.current)
-  }, [parent]);
 
   const onClick = (e: any) => {
     setShow(false);


### PR DESCRIPTION
remove auto-animate package and use css transitions/animations

## Describe your changes
Tydeligvis har auto-animate noen problemer med eldre versjoner av noen bundlers. Dvs at vi får problemer med storybooken dersom vi skal bruke en nyere versjon av auto-animate, siden storybook bruker en eldre versjon av create-react-app. Fjernet auto-animate-pakken og lagde en css transition i stedet, siden den kun ble brukt ett sted.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

