### PR TITLE
fix: add type button to accordion item

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -71,6 +71,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
       {/* Header */}
       <button
         id={accordionId}
+        type="button"
         className={headerClassNames}
         disabled={!!disabled}
         onClick={(e: React.MouseEvent) => toggle(e)}
@@ -97,6 +98,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
 
           {!hideCloseButton &&
             <button
+              type="button"
               className="md-accordion-item__close-button"
               onClick={(e: React.MouseEvent) => toggle(e)}
               tabIndex={isExpanded ? 0 : -1}


### PR DESCRIPTION
## Describe your changes
When using MdAccordionItem inside forms, the buttons inside the accordion trigger form submission. Setting type="button" on them fixes this issue.

## Checklist before requesting a review
- [ x ] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

