### PR TITLE
fix: export prop interfaces for React components

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import MdMinusIcon from '../icons/MdMinusIcon';
 
-interface MdAccordionItemProps {
+export interface MdAccordionItemProps {
   label?: string;
   headerContent?: React.ReactNode | string;
   id?: string | number | null | undefined;

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -71,6 +71,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
       {/* Header */}
       <button
         id={accordionId}
+        type="button"
         className={headerClassNames}
         disabled={!!disabled}
         onClick={(e: React.MouseEvent) => toggle(e)}
@@ -97,6 +98,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
 
           {!hideCloseButton &&
             <button
+              type="button"
               className="md-accordion-item__close-button"
               onClick={(e: React.MouseEvent) => toggle(e)}
               tabIndex={isExpanded ? 0 : -1}

--- a/packages/react/src/button/MdButton.tsx
+++ b/packages/react/src/button/MdButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-interface MdButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface MdButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   theme?: string;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;

--- a/packages/react/src/fileList/MdFileList.tsx
+++ b/packages/react/src/fileList/MdFileList.tsx
@@ -14,7 +14,7 @@ interface FileType {
   type?: string
 };
 
-interface MdFileListProps {
+export interface MdFileListProps {
   files?: File[] | FileType[];
   hideDownload?: boolean;
   allowDelete?: boolean;

--- a/packages/react/src/formElements/MdFileUpload.tsx
+++ b/packages/react/src/formElements/MdFileUpload.tsx
@@ -6,7 +6,7 @@ import MdButton from '../button/MdButton';
 
 import MdUploadIcon from '../icons/MdUploadIcon';
 
-interface MdFileUploadProps {
+export interface MdFileUploadProps {
   onUpload?(files: File[] | FormData): void;
   onCancel?(e: MouseEvent): void;
   useFormData?: boolean;

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -14,7 +14,7 @@ interface MdMultiSelectOptionProps {
   value: string | number;
 };
 
-interface MdMultiSelectProps {
+export interface MdMultiSelectProps {
     label?: string | null;
     options?: MdMultiSelectOptionProps[];
     onChange?(e: React.ChangeEvent): void;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,31 +1,31 @@
-import MdButton from './button/MdButton';
-import MdCheckbox from './formElements/MdCheckbox';
-import MdCheckboxGroup from './formElements/MdCheckboxGroup';
-import MdInput from './formElements/MdInput';
-import MdSelect from './formElements/MdSelect';
-import MdMultiSelect from './formElements/MdMultiSelect';
-import MdRadioGroup from './formElements/MdRadioGroup';
-import MdTextArea from './formElements/MdTextArea';
-import MdFileUpload from './formElements/MdFileUpload';
-import MdLink from './link/MdLink';
-import MdHelpButton from './help/MdHelpButton';
-import MdHelpText from './help/MdHelpText';
-import MdToggle from './toggle/MdToggle';
-import MdClickOutsideWrapper from './utils/MdClickOutsideWrapper';
-import MdInputChip from './chips/MdInputChip';
-import MdFilterChip from './chips/MdFilterChip';
-import MdFileList from './fileList/MdFileList';
-import MdAccordionItem from './accordion/MdAccordionItem';
-import MdModal from './modal/MdModal';
-import MdTile from './tiles/MdTile';
-import MdTileVertical from './tiles/MdTileVertical';
-import MdTabs from './tabs/MdTabs';
-import MdTab from './tabs/MdTab';
-import MdTabTitle from './tabs/MdTabTitle';
-import MdLoadingSpinner from './loadingSpinner/MdLoadingSpinner';
-import MdInfoTag from './infoTag/MdInfoTag';
-import MdInfoBox from './messages/MdInfoBox';
-import MdAlertMessage from './messages/MdAlertMessage';
+import MdButton, { MdButtonProps } from './button/MdButton';
+import MdCheckbox, { MdCheckboxProps } from './formElements/MdCheckbox';
+import MdCheckboxGroup, { MdCheckboxGroupProps } from './formElements/MdCheckboxGroup';
+import MdInput, { MdInputProps } from './formElements/MdInput';
+import MdSelect, { MdSelectProps } from './formElements/MdSelect';
+import MdMultiSelect, { MdMultiSelectProps } from './formElements/MdMultiSelect';
+import MdRadioGroup, { MdRadioGroupProps } from './formElements/MdRadioGroup';
+import MdTextArea, { MdTextAreaProps } from './formElements/MdTextArea';
+import MdFileUpload, { MdFileUploadProps } from './formElements/MdFileUpload';
+import MdLink, { MdLinkProps } from './link/MdLink';
+import MdHelpButton, { MdHelpButtonProps } from './help/MdHelpButton';
+import MdHelpText, { MdHelpTextProps } from './help/MdHelpText';
+import MdToggle, { MdToggleProps } from './toggle/MdToggle';
+import MdClickOutsideWrapper, { MdClickOutsideWrapperProps } from './utils/MdClickOutsideWrapper';
+import MdInputChip, { MdInputChipProps } from './chips/MdInputChip';
+import MdFilterChip, { MdFilterChipProps } from './chips/MdFilterChip';
+import MdFileList, { MdFileListProps } from './fileList/MdFileList';
+import MdAccordionItem, { MdAccordionItemProps } from './accordion/MdAccordionItem';
+import MdModal, { MdModalProps } from './modal/MdModal';
+import MdTile, { MdTileProps } from './tiles/MdTile';
+import MdTileVertical, { MdTileVerticalProps } from './tiles/MdTileVertical';
+import MdTabs, { MdTabsProps } from './tabs/MdTabs';
+import MdTab, { MdTabProps } from './tabs/MdTab';
+import MdTabTitle, { MdTabTitleProps } from './tabs/MdTabTitle';
+import MdLoadingSpinner, { MdLoadingSpinnerProps } from './loadingSpinner/MdLoadingSpinner';
+import MdInfoTag, { MdInfoTagProps } from './infoTag/MdInfoTag';
+import MdInfoBox, { MdInfoBoxProps } from './messages/MdInfoBox';
+import MdAlertMessage, { MdAlertMessageProps } from './messages/MdAlertMessage';
 
 // Icons
 import MdCalendarDayIcon from './icons/MdCalendarDayIcon';
@@ -152,6 +152,35 @@ export {
   MdInfoTag,
   MdInfoBox,
   MdAlertMessage,
+
+  MdButtonProps,
+  MdCheckboxProps,
+  MdCheckboxGroupProps,
+  MdInputProps,
+  MdSelectProps,
+  MdMultiSelectProps,
+  MdRadioGroupProps,
+  MdTextAreaProps,
+  MdFileUploadProps,
+  MdLinkProps,
+  MdHelpButtonProps,
+  MdHelpTextProps,
+  MdToggleProps,
+  MdClickOutsideWrapperProps,
+  MdInputChipProps,
+  MdFilterChipProps,
+  MdFileListProps,
+  MdAccordionItemProps,
+  MdModalProps,
+  MdTileProps,
+  MdTileVerticalProps,
+  MdTabsProps,
+  MdTabProps,
+  MdTabTitleProps,
+  MdLoadingSpinnerProps,
+  MdInfoTagProps,
+  MdInfoBoxProps,
+  MdAlertMessageProps,
 
   MdCalendarDayIcon, MdCalendarDay64Icon,
   MdCalendarIcon, MdCalendarIcon64,

--- a/packages/react/src/infoTag/MdInfoTag.tsx
+++ b/packages/react/src/infoTag/MdInfoTag.tsx
@@ -8,7 +8,7 @@ import MdCancelIcon from "../icons/MdCancelIcon";
 type ThemeTypes = null | undefined | '' | 'primary' | 'secondary' | 'warning' | 'danger';
 type IconTypes = null | undefined | '' | 'none' | 'info' | 'warning' | 'error' | 'custom';
 
-interface MdInfoTagProps {
+export interface MdInfoTagProps {
   theme?: ThemeTypes;
   keepOpen?: boolean;
   label?: string;

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface MdLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface MdLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children?: string | React.ReactNode;
   href?: string;
   onClick?(e: React.MouseEvent): void;

--- a/packages/react/src/loadingSpinner/MdLoadingSpinner.tsx
+++ b/packages/react/src/loadingSpinner/MdLoadingSpinner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import MdLoadingSpinnerIcon from '../icons/MdLoadingSpinnerIcon';
 
-interface MdLoadingSpinnerProps {
+export interface MdLoadingSpinnerProps {
   size?: number;
   position?: string;
   className?: string;

--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -6,7 +6,7 @@ import MdWarningIcon from "../icons/MdWarningIcon";
 import MdCheckIcon from "../icons/MdCheckIcon";
 import MdXIcon from "../icons/MdXIcon";
 
-interface MdAlertMessageProps {
+export interface MdAlertMessageProps {
   theme?: 'info' | 'confirm' | 'warning' | 'error';
   label?: string;
   hideIcon?: boolean;

--- a/packages/react/src/messages/MdInfoBox.tsx
+++ b/packages/react/src/messages/MdInfoBox.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import classnames from 'classnames';
 import MdInfoIcon from "../icons/MdInfoIcon";
 
-interface MdInfoBoxProps {
+export interface MdInfoBoxProps {
   label: string;
   hideIcon?: boolean;
   fullWidth?: boolean;

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 import MdXIcon from '../icons/MdXIcon';
 
-interface MdModalProps {
+export interface MdModalProps {
   children: any;
   heading?: string;
   headingIcon?: React.ReactNode | string;

--- a/packages/react/src/tabs/MdTab.tsx
+++ b/packages/react/src/tabs/MdTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface MdTabProps {
+export interface MdTabProps {
   title: string
   disabled?: boolean
   children: React.ReactNode

--- a/packages/react/src/tabs/MdTabTitle.tsx
+++ b/packages/react/src/tabs/MdTabTitle.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-interface MdTabTitleProps {
+export interface MdTabTitleProps {
   title: string
   index: number
   disabled?: boolean

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 import MdTabTitle from './MdTabTitle';
 
-interface MdTabsProps {
+export interface MdTabsProps {
   children: ReactElement[];
 };
 

--- a/packages/react/src/tiles/MdTile.tsx
+++ b/packages/react/src/tiles/MdTile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import MdChevronIcon from '../icons/MdChevronIcon';
 
-interface MdTileProps {
+export interface MdTileProps {
   heading?: string;
   description?: string;
   href?: string;

--- a/packages/react/src/tiles/MdTileVertical.tsx
+++ b/packages/react/src/tiles/MdTileVertical.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-interface MdTileVerticalProps {
+export interface MdTileVerticalProps {
   heading?: string;
   description?: string;
   size?: string;

--- a/packages/react/src/utils/MdClickOutsideWrapper.tsx
+++ b/packages/react/src/utils/MdClickOutsideWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-interface MdClickOutsideWrapperProps {
+export interface MdClickOutsideWrapperProps {
   onClickOutside(e: React.MouseEvent): void;
   children: React.ReactNode;
   className?: any;


### PR DESCRIPTION
## Describe your changes
Export the prop interfaces for all the exported React components. This was needed to be able to refer to the prop types in other projects, in my case for creating wrapper components in Next.js 13. app router.

## Checklist before requesting a review
- [ X ] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

