### PR TITLE
fix: add type button to help button

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/help/MdHelpButton.tsx
+++ b/packages/react/src/help/MdHelpButton.tsx
@@ -27,6 +27,7 @@ const MdHelpButton: React.FunctionComponent<MdHelpButtonProps> = ({
       {...otherProps}
       className={buttonClasses}
       onClick={onClick}
+      type="button"
     >
       <MdHelpIcon className="md-helpbutton__icon" />
     </button>


### PR DESCRIPTION
## Describe your changes
When MdHelpButton is used inside a form, clicking the help text button triggers a form submission since it does not have a button type. Add type="button".

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

