### PR TITLE
button resizing fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-components",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Miljødirektoratets komponentbibliotek",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Miljødirektoratets komponentbibliotek",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -8,29 +8,31 @@
   font-family: 'Open sans';
   font-size: 1rem;
   outline: 2px solid var(--mdPrimaryColor);
-  padding: .65rem 1.5rem;
+  padding: 0.65rem 1.5rem;
   width: fit-content;
 }
 
 .md-button--small {
-  padding: .4rem .8rem;
-  border-radius: .43rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.43rem;
 }
 
 .md-button__leftIcon {
-  height: 16px;
-  width: 16px;
+  height: 1rem;
+  width: 1rem;
   position: relative;
-  right: 8px;
+  right: 0.5rem;
   top: 0;
+  flex-shrink: 0;
 }
 
 .md-button__rightIcon {
-  height: 16px;
-  width: 16px;
+  height: 1rem;
+  width: 1rem;
   position: relative;
-  left: 8px;
+  left: 0.5rem;
   top: 0;
+  flex-shrink: 0;
 }
 
 .md-button:focus {


### PR DESCRIPTION
## Describe your changes
Changed unit for height, width, right and left on both icon classes so that size and positioning of icon is adjusted accordingly, when font size on the button changes. This is to avoid the current problem, where the icon stays small and wrongly positioned in relation to the text of the button when text has been increased in the user's browser:
![image](https://github.com/miljodir/md-components/assets/108116520/da1a4e33-06ab-442a-9da0-58b3e119f755)

Also added flex-shrink: 0 to both icon classes so that icons won't shrink in size if the button is pressed for available space. Reproduceable when minimizing the browser window so that button text wraps across rows:
![image](https://github.com/miljodir/md-components/assets/108116520/57b9deba-dd0f-451e-9fdc-e610b8980daf)


## Checklist before requesting a review
- [X] I have performed a self-review and test of my code
- [x] If new component: Is story for component created in `stories`-folder?
- [x] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [x] If new component: Is css-file added to `packages/css/index.css`?

