### PR TITLE
Dont override md-classes when adding className prop to button and link

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/button/MdButton.tsx
+++ b/packages/react/src/button/MdButton.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import classnames from 'classnames';
+import React from 'react';
 
-export interface MdButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface MdButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   theme?: string;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   children?: string | React.ReactNode;
-  small?: boolean,
-  type?: "button" | "submit" | "reset" | undefined;
+  small?: boolean;
+  type?: 'button' | 'submit' | 'reset' | undefined;
 }
 
 const MdButton: React.FunctionComponent<MdButtonProps> = ({
@@ -19,14 +20,18 @@ const MdButton: React.FunctionComponent<MdButtonProps> = ({
   type = 'button',
   ...otherProps
 }: MdButtonProps) => {
-  const classNames = classnames('md-button', {
-    'md-button--small': !!small,
-    'md-button--secondary': theme === 'secondary',
-    'md-button--danger': theme === 'danger',
-  });
+  const classNames = classnames(
+    'md-button',
+    {
+      'md-button--small': !!small,
+      'md-button--secondary': theme === 'secondary',
+      'md-button--danger': theme === 'danger',
+    },
+    otherProps.className
+  );
 
   return (
-    <button className={classNames} type={type} {...otherProps}>
+    <button type={type} {...otherProps} className={classNames}>
       {leftIcon && <div className="md-button__leftIcon">{leftIcon}</div>}
       {children}
       {rightIcon && <div className="md-button__rightIcon">{rightIcon}</div>}

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -1,6 +1,8 @@
+import classnames from 'classnames';
 import React from 'react';
 
-export interface MdLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface MdLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children?: string | React.ReactNode;
   href?: string;
   onClick?(e: React.MouseEvent): void;
@@ -9,10 +11,13 @@ export interface MdLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElemen
 const MdLink: React.FunctionComponent<MdLinkProps> = ({
   children,
   ...otherProps
-}: MdLinkProps) => (
-  <a className="md-link" {...otherProps}>
-    {children}
-  </a>
-);
+}: MdLinkProps) => {
+  const classNames = classnames('md-link', otherProps.className);
+  return (
+    <a {...otherProps} className={classNames}>
+      {children}
+    </a>
+  );
+};
 
 export default MdLink;


### PR DESCRIPTION
## Describe your changes
Changed order of applied props to button and link elements. Otherwise adding a className property when using MdLink or MdButton component will effectively remove the internal classes that style them correctly.

Also made sure that the resulting classes added on the element include both the internal classes and any applied from the outside, so that it is possible to further style the component where it is being used.

NB: If allowing users of the component library to extend styling in this way is accepted, the same logic should be added to all the components, not just MdLink and MdButton as I've done here.

## Checklist before requesting a review
- [X] I have performed a self-review and test of my code
- [X] If new component: Is story for component created in `stories`-folder?
- [X] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [X] If new component: Is css-file added to `packages/css/index.css`?

