### PR TITLE
opportunity to override icons in info boxes

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React from 'react';
 import classnames from 'classnames';
 
-import MdInfoIcon from "../icons/MdInfoIcon";
-import MdWarningIcon from "../icons/MdWarningIcon";
-import MdCheckIcon from "../icons/MdCheckIcon";
-import MdXIcon from "../icons/MdXIcon";
+import MdInfoIcon from '../icons/MdInfoIcon';
+import MdWarningIcon from '../icons/MdWarningIcon';
+import MdCheckIcon from '../icons/MdCheckIcon';
+import MdXIcon from '../icons/MdXIcon';
 
 export interface MdAlertMessageProps {
   theme?: 'info' | 'confirm' | 'warning' | 'error';
@@ -13,7 +13,8 @@ export interface MdAlertMessageProps {
   closable?: boolean;
   fullWidth?: boolean;
   onClose?(e: React.MouseEvent): void;
-};
+  customIcon?: React.ReactNode | string;
+}
 
 const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   theme = 'info',
@@ -21,7 +22,8 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   hideIcon = false,
   closable = false,
   fullWidth = false,
-  onClose
+  onClose,
+  customIcon,
 }: MdAlertMessageProps) => {
   const classNames = classnames('md-alert-message', {
     'md-alert-message--fullWidth': !!fullWidth,
@@ -31,21 +33,22 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   });
 
   const renderIcon = () => {
-    let icon = <MdInfoIcon width="20" height="20" />
-    if (theme === 'confirm') {
-      icon = <MdCheckIcon width="20" height="20" />
+    let icon = (<MdInfoIcon width="20" height="20" />) as React.ReactNode;
+    if (customIcon) {
+      icon = customIcon;
+    } else if (theme === 'confirm') {
+      icon = <MdCheckIcon width="20" height="20" />;
     } else if (theme === 'warning' || theme === 'error') {
-      icon = <MdWarningIcon width="20" height="20" />
+      icon = <MdWarningIcon width="20" height="20" />;
     }
     return icon;
-  }
+  };
 
   const clickHandler = (e: React.MouseEvent) => {
-    // console.log(e);
     if (onClose) {
       onClose(e);
     }
-  }
+  };
 
   return (
     <div className={classNames}>
@@ -54,14 +57,14 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
         {label}
       </div>
 
-      {!!closable && onClose &&
+      {!!closable && onClose && (
         <button
           className="md-alert-message__button"
           onClick={(e) => clickHandler(e)}
         >
           <MdXIcon width="16" height="16" />
         </button>
-      }
+      )}
     </div>
   );
 };

--- a/packages/react/src/messages/MdInfoBox.tsx
+++ b/packages/react/src/messages/MdInfoBox.tsx
@@ -1,30 +1,38 @@
-import React from "react";
+import React from 'react';
 import classnames from 'classnames';
-import MdInfoIcon from "../icons/MdInfoIcon";
+import MdInfoIcon from '../icons/MdInfoIcon';
 
 export interface MdInfoBoxProps {
   label: string;
   hideIcon?: boolean;
   fullWidth?: boolean;
-};
+  customIcon?: React.ReactNode | string;
+}
 
 const MdInfoBox: React.FC<MdInfoBoxProps> = ({
   label,
   hideIcon = false,
-  fullWidth = false
+  fullWidth = false,
+  customIcon,
 }: MdInfoBoxProps) => {
   const classNames = classnames('md-info-box', {
-    'md-info-box--fullWidth': !!fullWidth
+    'md-info-box--fullWidth': !!fullWidth,
   });
+
+  const renderIcon = () => {
+    let icon = (<MdInfoIcon width="20" height="20" />) as React.ReactNode;
+    if (customIcon) {
+      icon = customIcon;
+    }
+    return icon;
+  };
 
   return (
     <div className={classNames}>
-      {!hideIcon &&
-        <MdInfoIcon width="20" height="20" />
-      }
+      {!hideIcon && renderIcon()}
       {label}
     </div>
   );
-}
+};
 
 export default MdInfoBox;

--- a/stories/Messages/AlertMessage.stories.tsx
+++ b/stories/Messages/AlertMessage.stories.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from "react";
-import { ComponentStory } from "@storybook/react";
+import React, { useState, useEffect, useRef } from 'react';
+import { ComponentStory } from '@storybook/react';
 import {
   Title,
   Subtitle,
@@ -31,23 +31,24 @@ export default {
         </>
       ),
       description: {
-        component: "A component for alerts. Closable/removable by default.<br/><br/>`import { MdAlertMessage } from '@miljodirektoratet/md-react'`",
+        component:
+          "A component for alerts. Closable/removable by default.<br/><br/>`import { MdAlertMessage } from '@miljodirektoratet/md-react'`",
       },
     },
   },
   argTypes: {
     label: {
       type: { name: 'string', required: true },
-      description: "The text to display on hover",
+      description: 'The text to display on hover',
       table: {
         type: {
           summary: 'text',
         },
       },
-      control: 'text'
+      control: 'text',
     },
     theme: {
-      description: "Theme of alert message",
+      description: 'Theme of alert message',
       table: {
         type: {
           defaultValue: { summary: 'info' },
@@ -58,14 +59,15 @@ export default {
       control: { type: 'inline-radio' },
     },
     fullWidth: {
-      description: 'Make alert message full width. Non-full width has max-width = 634px',
+      description:
+        'Make alert message full width. Non-full width has max-width = 634px',
       table: {
         defaultValue: { summary: 'false' },
         type: {
           summary: 'boolean',
         },
       },
-      control: { type: 'boolean' }
+      control: { type: 'boolean' },
     },
     hideIcon: {
       description: 'Hide alert icon.',
@@ -75,12 +77,21 @@ export default {
           summary: 'boolean',
         },
       },
-      control: { type: 'boolean' }
+      control: { type: 'boolean' },
     },
-  }
+    customIcon: {
+      description: 'Custom icon. Overrides theme icon.',
+      table: {
+        type: {
+          summary: 'DomElement | image | ReactNode',
+        },
+      },
+      control: null,
+    },
+  },
 };
 
-const Template: ComponentStory<typeof MdAlertMessage> = args => {
+const Template: ComponentStory<typeof MdAlertMessage> = (args) => {
   const [show, setShow] = useState(true);
   const parent = useRef(null);
 
@@ -89,13 +100,11 @@ const Template: ComponentStory<typeof MdAlertMessage> = args => {
     setTimeout(() => {
       setShow(true);
     }, 700);
-  }
+  };
 
   return (
     <div ref={parent}>
-      {show &&
-        <MdAlertMessage {...args} onClose={onClick} />
-      }
+      {show && <MdAlertMessage {...args} onClose={onClick} />}
     </div>
   );
 };
@@ -106,5 +115,5 @@ AlertMessage.args = {
   label: 'This is an alert message.',
   hideIcon: false,
   closable: true,
-  fullWidth: false
+  fullWidth: false,
 };

--- a/stories/Messages/InfoBox.stories.tsx
+++ b/stories/Messages/InfoBox.stories.tsx
@@ -31,20 +31,21 @@ export default {
         </>
       ),
       description: {
-        component: "A component for info box.<br/><br/>`import { MdInfoBox } from '@miljodirektoratet/md-react'`",
+        component:
+          "A component for info box.<br/><br/>`import { MdInfoBox } from '@miljodirektoratet/md-react'`",
       },
     },
   },
   argTypes: {
     label: {
       type: { name: 'string', required: true },
-      description: "The text to display on hover",
+      description: 'The text to display on hover',
       table: {
         type: {
           summary: 'text',
         },
       },
-      control: 'text'
+      control: 'text',
     },
     hideIcon: {
       description: 'Hide default icon.',
@@ -54,19 +55,29 @@ export default {
           summary: 'boolean',
         },
       },
-      control: { type: 'boolean' }
+      control: { type: 'boolean' },
     },
     fullWidth: {
-      description: 'Make info box full width. Non-full width has max-width = 634px',
+      description:
+        'Make info box full width. Non-full width has max-width = 634px',
       table: {
         defaultValue: { summary: 'false' },
         type: {
           summary: 'boolean',
         },
       },
-      control: { type: 'boolean' }
+      control: { type: 'boolean' },
     },
-  }
+    customIcon: {
+      description: 'Custom icon. Overrides theme icon.',
+      table: {
+        type: {
+          summary: 'DomElement | image | ReactNode',
+        },
+      },
+      control: null,
+    },
+  },
 };
 
 const Template: ComponentStory<typeof MdInfoBox> = args => {


### PR DESCRIPTION
## Describe your changes
Lagt til mulighet for egendefinerte ikoner i infobox og alertmessage. 
På denne måten kan også størrelse, farge og rotasjon på ikonet endres.

Overskrives ved å legge til i argumenter, som for eksempel:

`<MdAlertMessage
        label='Feilmeldinger'
        theme='error'
        customIcon={<MdCloseIcon width={20} height={20} color='white' />}
      />`


## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

