### PR TITLE
Preserve input element id

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -26,6 +26,8 @@ export interface MdInputProps {
   onChange?(e: React.ChangeEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
+  minLength?: number;
+  maxLength?: number;
 };
 
 const MdInput: React.FunctionComponent<MdInputProps> = ({

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import classnames from 'classnames';
+import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
@@ -68,7 +68,7 @@ const MdInput: React.FunctionComponent<MdInputProps> = ({
     <div className={`md-input__outer-wrapper ${outerWrapperClass}`}>
       <div className="md-input__label">
         {label && label !== '' &&
-          <label htmlFor={`md-input_${inputId}`}>
+          <label htmlFor={inputId}>
             {label}
           </label>
         }
@@ -96,7 +96,7 @@ const MdInput: React.FunctionComponent<MdInputProps> = ({
           </div>
         }
         <input
-          id={`md-input_${inputId}`}
+          id={inputId}
           className={classNames}
           value={value}
           type={type}


### PR DESCRIPTION
## Describe your changes
Preserve the id set on the input element from incomming props. To allow any parent components to know the input's id and be able to reference the element by that id.

When the incomming id is prefixed with "md-input_" the outside world no longer knows the actual id of the input element and can't reference it correctly. I haven't been able to figure out why it was coded this way originally, and what drawback there would be to just using the incomming id plainly... Hoping to hear from anyone who knows more about the decisions that was made when the component was created :) 

Also desirable to be able to set min/maxLength props on input element, to help users not write longer text than they're allowed. So I added minLength and maxLength to "otherProps" that are just forwarded to the input-element. ok?

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [x] If new component: Is story for component created in `stories`-folder?
- [x] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [x] If new component: Is css-file added to `packages/css/index.css`?

