### PR TITLE
Ref prop on inputs

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -29,6 +29,7 @@ export interface MdInputProps {
   onKeyDown?(e: React.KeyboardEvent<HTMLInputElement>): void;
   minLength?: number;
   maxLength?: number;
+  inputRef?: React.Ref<HTMLInputElement>;
 };
 
 const MdInput: React.FunctionComponent<MdInputProps> = ({
@@ -48,6 +49,7 @@ const MdInput: React.FunctionComponent<MdInputProps> = ({
   suffix = undefined,
   prefixIcon = null,
   hideNumberArrows = false,
+  inputRef,
   ...otherProps
 }: MdInputProps) => {
   const [helpOpen, setHelpOpen] = useState(false);
@@ -106,6 +108,7 @@ const MdInput: React.FunctionComponent<MdInputProps> = ({
           placeholder={placeholder}
           disabled={!!disabled}
           readOnly={!!readOnly}
+          ref={inputRef}
           {...otherProps}
         />
 

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
+import React, { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
-import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper'
 import MdChevronIcon from '../icons/MdChevronIcon';
 import MdXIcon from '../icons/MdXIcon';
+import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 
 interface MdSelectOptionProps {
   text: string;
@@ -26,6 +26,7 @@ export interface MdSelectProps {
     helpText?: string;
     error?: boolean;
     errorText?: string;
+    selectRef?: React.Ref<HTMLButtonElement>;
 };
 
 const MdSelect: React.FunctionComponent<MdSelectProps> = ({
@@ -41,7 +42,7 @@ const MdSelect: React.FunctionComponent<MdSelectProps> = ({
   error = false,
   errorText,
   onChange,
-  ...otherProps
+  selectRef
 }: MdSelectProps) => {
   const [open, setOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -140,6 +141,7 @@ const MdSelect: React.FunctionComponent<MdSelectProps> = ({
           type='button'
           tabIndex={0}
           onClick={() => !disabled && setOpen(!open)}
+          ref={selectRef}
         >
           <div className="md-select__button-text">{displayValue}</div>
           <div className="md-select__button-icon">

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -1,14 +1,14 @@
-import React from 'react'
-import { useArgs } from '@storybook/client-api';
 import {
-  Title,
-  Subtitle,
-  Description,
-  Primary,
   ArgsTable,
-  Stories,
+  Description,
   PRIMARY_STORY,
+  Primary,
+  Stories,
+  Subtitle,
+  Title,
 } from '@storybook/addon-docs';
+import { useArgs } from '@storybook/client-api';
+import React from 'react';
 // @ts-ignore
 import Readme from '../packages/css/src/formElements/input/README.md';
 
@@ -217,6 +217,51 @@ export default {
           summary: "function",
         },
       },
+    },
+    onBlur: {
+      type: { name: "function"},
+      description: "The onBlur handler for blur events on input",
+      table: {
+        type: {
+          summary: "function"
+        }
+      }
+    },
+    onFocus: {
+      type: { name: "function"},
+      description: "The onFocus handler for focus events on input",
+      table: {
+        type: {
+          summary: "function"
+        }
+      }
+    },
+    onKeyDown: {
+      type: { name: "function"},
+      description: "The onKeyDown handler for key down events on input",
+      table: {
+        type: {
+          summary: "function"
+        },
+      },
+    },
+    minLength: {
+      type: { name: 'number'},
+      description: "The minimum length of input value",
+      table: {
+        type: { summary: "number" }
+      },
+    },
+    maxLength: {
+      type: { name: "number" },
+      description: "The maximum length of input value",
+      table: {
+        type: { summary: "number"},
+      },
+    },
+    inputRef: {
+      type: { name: "Ref<HTMLInputElement>" },
+      description: "Ref to the inner input element, use for example to bring focus to the input when there's an error."
     }
   }
 }

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { useArgs } from '@storybook/client-api';
 import {
-  Title,
-  Subtitle,
-  Description,
-  Primary,
   ArgsTable,
-  Stories,
+  Description,
   PRIMARY_STORY,
+  Primary,
+  Stories,
+  Subtitle,
+  Title,
 } from '@storybook/addon-docs';
+import { useArgs } from '@storybook/client-api';
+import React from 'react';
 // @ts-ignore
 import Readme from '../packages/css/src/formElements/select/README.md';
 
@@ -138,6 +138,10 @@ export default {
           summary: "function",
         },
       },
+    },
+    selectRef: {
+      type: { name: "Ref<HTMLButtonElement>"},
+      description: "Ref to the button element that toggles the select dropdown, use for example to bring focus to the component when there's an error."
     }
   }
 };


### PR DESCRIPTION
## Describe your changes
Added ref-property to MdInput and MdSelect. To be able to focus on the inner input element/button element from the outside, when there is a form error for example.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

