### PR TITLE
feat: add MdAutocomplete component

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/autocomplete/README.md
+++ b/packages/css/src/formElements/autocomplete/README.md
@@ -1,0 +1,58 @@
+# Structure
+
+To use the `Autocomplete` css in `@miljodirektoratet/md-css` as a standalone, without the accompanying React component, please use the following HTML structure.
+
+Class names in brackets [] are optional-/togglable-/decorator- or state dependant classes.
+
+See [Storybook](https://miljodir.github.io/md-components) for examples and more info.
+
+```html
+<div className="md-autocomplete [md-autocomplete--open, md-autocomplete--disabled, md-autocomplete--medium, md-autocomplete--small, md-autocomplete--error]">
+    <div className="md-autocomplete__label">
+        <div>{label}</div>
+        <div className="md-autocomplete__help-button">
+            {button to trigger help text}
+        </div>
+    </div>
+
+    <div className="md-autocomplete__help-text [md-autocomplete__help-text--open]">
+        {helpText}
+    </div>
+
+    <MdClickOutsideWrapper> <- optional wrapper to close autocomplete box when clicking outside
+        <!-- Optional prefix-icon -->
+        <div className="md-autocomplete__input__prefix [md-autocomplete__input__prefix--disabled]">
+            {prefixIcon}
+        </div>
+
+        <input
+            id=""
+            className="md-autocomplete__input [md-autocomplete__input--open, md-autocomplete__input--error, md-autocomplete__input--has-prefix]"
+            value={value}
+            ...
+        />
+
+        <div className="md-autocomplete__input-icon">
+            <MdChevronIcon />
+        </div>
+
+        <div className="md-autocomplete__dropdown">
+            <button
+                tabIndex={open ? 0: -1}
+                className="md-autocomplete__dropdown-item [md-autocomplete__dropdown-item--selected]"
+                onClick={function to handle select|deselect option}
+            >
+            <div className="md-autocomplete__dropdown-item-text">{option.text}</div>
+
+            {if seleceted option
+                <div className="md-autocomplete__dropdown-item-clear" title="Klikk for å fjerne valg">
+                    <MdXIcon />
+                </div>
+            }
+
+            </button>
+        </div>
+    </MdClickOutsideWrapper>
+    <div className="md-autocomplete__error">{errorText}</div>
+</div>
+```

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -1,0 +1,198 @@
+.md-autocomplete {
+  font-family: 'Open sans';
+  width: 634px;
+  max-width: 100%;
+}
+
+.md-autocomplete--medium {
+  width: 440px;
+}
+
+.md-autocomplete--small {
+  width: 260px;
+}
+
+.md-autocomplete__container {
+  position: relative;
+}
+
+.md-autocomplete__label {
+  display: flex;
+  align-items: flex-end;
+  font-weight: 600;
+}
+
+.md-autocomplete__label > * + * {
+  margin-left: 1em;
+}
+
+.md-autocomplete__input {
+  max-width: 100%;
+  width: 100%;
+  background-color: #fff;
+  border-radius: 0;
+  color: var(--mdGreyColor);
+  box-sizing: border-box;
+  font-family: 'Open sans';
+  font-size: 1em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1em;
+  border: 1px solid var(--mdGreyColor60);
+  margin: .8em 0 0 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.md-autocomplete__input.md-autocomplete__input--error {
+  border-color: var(--mdErrorColor);
+}
+
+.md-autocomplete--disabled .md-autocomplete__input {
+  background-color: var(--mdGreyColor20);
+  color: var(--mdGreyColor60);
+  cursor: not-allowed;
+}
+
+.md-autocomplete__input:focus,
+.md-autocomplete__input:focus-within {
+  outline: none;
+}
+
+.md-autocomplete__input-text {
+  display: flex;
+  flex-grow: 1;
+  padding-right: 1em;
+}
+
+.md-autocomplete__input-icon {
+  display: flex;
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  rotate: 90deg;
+  color: var(--mdGreyColor);
+}
+
+.md-autocomplete__input.md-autocomplete__input--has-prefix {
+  padding-left: 2.5em;
+}
+
+.md-autocomplete__input--small.md-autocomplete__input--has-prefix {
+  padding-left: 1.8em;
+}
+
+.md-autocomplete__input__prefix {
+  position: absolute;
+  top: 1.3em;
+  left: 1em;
+  height: 16px;
+  width: 16px;
+  display: flex;
+  color: var(--mdPrimaryColor);
+}
+
+.md-autocomplete__input__prefix.md-autocomplete__input__prefix--disabled {
+  color: var(--mdGreyColor60);
+}
+
+.md-autocomplete__input-icon {
+  position: absolute;
+  top: 1.3em;
+  right: .9em;
+  display: flex;
+  width: 15px;
+  height: 15px;
+  rotate: 90deg;
+  color: var(--mdGreyColor);
+}
+
+.md-autocomplete__help-text {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.15s ease-out;
+}
+
+.md-autocomplete__help-text--open {
+  padding-top: .5em;
+  max-height: 2000px;
+  transition: max-height 0.5s ease-in;
+}
+
+.md-autocomplete__dropdown {
+  position: absolute;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height .5s ease-in-out;
+  width: calc(100% - 4px); /* Full width minus border-width */
+}
+
+.md-autocomplete__dropdown-item {
+  display: flex;
+  font-family: 'Open sans';
+  border: 0;
+  background-color: #fff;
+  width: 100%;
+  text-align: left;
+  padding: .9em;
+  transition: background-color .15s ease-in-out;
+  cursor: pointer;
+}
+
+.md-autocomplete__dropdown-item:hover,
+.md-autocomplete__dropdown-item:focus {
+  outline: none;
+  background-color: var(--mdPrimaryColor20);
+  transition: background-color .15s ease-in-out;
+}
+
+.md-autocomplete__dropdown-item--selected {
+  background-color: var(--mdPrimaryColor10);
+}
+
+.md-autocomplete__dropdown-item-text {
+  display: flex;
+  flex-grow: 1;
+}
+
+.md-autocomplete__dropdown-item-clear {
+  display: flex;
+  flex-shrink: 0;
+  height: 12px;
+  width: 12px;
+  color: var(--mdPrimaryColor);
+}
+
+/* Open state */
+.md-autocomplete--open .md-autocomplete__input {
+  border-left: 2px solid var(--mdPrimaryColor);
+  border-right: 2px solid var(--mdPrimaryColor);
+  border-top: 2px solid var(--mdPrimaryColor);
+}
+
+.md-autocomplete--open .md-autocomplete__dropdown {
+  max-height: 350px;
+  overflow-y: auto;
+  opacity: 1;
+  transition: max-height .5s ease-in-out;
+  border-right: 2px solid var(--mdPrimaryColor);
+  border-left: 2px solid var(--mdPrimaryColor);
+  border-bottom: 2px solid var(--mdPrimaryColor);
+  z-index: 2;
+}
+
+/* open + error */
+.md-autocomplete--open.md-autocomplete--error .md-autocomplete__input {
+  border-color: var(--mdErrorColor);
+}
+.md-autocomplete--open.md-autocomplete--error .md-autocomplete__dropdown {
+  border-color: var(--mdErrorColor);
+}
+
+/* Error text */
+.md-autocomplete__error {
+  color: var(--mdErrorColor);
+  font-size: .88em;
+}

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -18,6 +18,7 @@
 @import './formElements/checkboxgroup/checkboxgroup.css';
 @import './formElements/textarea/textarea.css';
 @import './formElements/select/select.css';
+@import './formElements/autocomplete/autocomplete.css';
 @import './formElements/radiogroup/radiogroup.css';
 @import './formElements/multiselect/multiselect.css';
 @import './formElements/fileupload/fileupload.css';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -1,0 +1,213 @@
+import classnames from 'classnames';
+import React, { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import MdHelpButton from '../help/MdHelpButton';
+import MdHelpText from '../help/MdHelpText';
+import MdXIcon from '../icons/MdXIcon';
+import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
+import MdChevronIcon from '../icons/MdChevronIcon';
+
+interface MdAutocompleteOptionProps {
+  text: string;
+  value: string;
+}
+
+export interface MdAutocompleteProps {
+  label?: string | null;
+  options: MdAutocompleteOptionProps[];
+  defaultOptions?: MdAutocompleteOptionProps[];
+  id?: string | number | null | undefined;
+  onChange(e: MdAutocompleteOptionProps): void;
+  name?: string;
+  value?: string | number;
+  placeholder?: string;
+  disabled?: boolean;
+  size?: string;
+  helpText?: string;
+  error?: boolean;
+  errorText?: string;
+  prefixIcon?: React.ReactNode;
+  inputRef?: React.Ref<HTMLInputElement>;
+}
+
+const MdAutocomplete: React.FunctionComponent<MdAutocompleteProps> = ({
+  label,
+  value,
+  options,
+  defaultOptions,
+  id = null,
+  name,
+  placeholder = 'Søk',
+  disabled = false,
+  size,
+  helpText,
+  error = false,
+  errorText,
+  prefixIcon = null,
+  onChange,
+  inputRef,
+  ...otherProps
+}: MdAutocompleteProps) => {
+  const [open, setOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [autocompleteValue, setAutocompleteValue] = useState('');
+  const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
+
+  const uuid = id || uuidv4();
+  const inputId = id && id !== '' ? id : uuidv4();
+
+  const classNames = classnames('md-autocomplete', {
+    'md-autocomplete--open': !!open,
+    'md-autocomplete--error': !!error,
+    'md-autocomplete--disabled': !!disabled,
+    'md-autocomplete--medium': size === 'medium',
+    'md-autocomplete--small': size === 'small',
+  });
+
+  const inputClassNames = classnames('md-autocomplete__input', {
+    'md-autocomplete__input--open': !!open,
+    'md-autocomplete__input--error': !!error,
+    'md-autocomplete__input--has-prefix':
+      prefixIcon !== null && prefixIcon !== '',
+  });
+
+  const selectedOption =
+    value && value !== ''
+      ? options && options.find((o) => o.value === value)
+      : '';
+
+  let displayValue = placeholder;
+  if (selectedOption && selectedOption.value) {
+    displayValue = selectedOption.text;
+  }
+  if (open) {
+    displayValue = '';
+  }
+
+  const handleOptionClick = (option: MdAutocompleteOptionProps) => {
+    onChange(option);
+    setOpen(false);
+    setAutocompleteValue('');
+  };
+
+  const isSelectedOption = (option: MdAutocompleteOptionProps) => {
+    return value && value !== '' && value == option.value;
+  };
+
+  const optionClass = (option: MdAutocompleteOptionProps) => {
+    return classnames('md-autocomplete__dropdown-item', {
+      'md-autocomplete__dropdown-item--selected': isSelectedOption(option),
+    });
+  };
+
+  return (
+    <div className={classNames}>
+      <div className="md-autocomplete__label">
+        <div>{label}</div>
+        {helpText && helpText !== '' && (
+          <div className="md-autocomplete__help-button">
+            <MdHelpButton
+              onClick={() => setHelpOpen(!helpOpen)}
+              expanded={helpOpen}
+            />
+          </div>
+        )}
+      </div>
+
+      {helpText && helpText !== '' && (
+        <div
+          className={`md-autocomplete__help-text ${
+            helpOpen ? 'md-autocomplete__help-text--open' : ''
+          }`}
+        >
+          <MdHelpText>{helpText}</MdHelpText>
+        </div>
+      )}
+
+      <MdClickOutsideWrapper
+        onClickOutside={() => setOpen(false)}
+        className="md-autocomplete__container"
+      >
+        {prefixIcon && (
+          <div
+            className={`${classnames('md-autocomplete__input__prefix', {
+              'md-autocomplete__input__prefix--disabled': !!disabled,
+            })}`}
+          >
+            {prefixIcon}
+          </div>
+        )}
+        <input
+          id={inputId}
+          className={inputClassNames}
+          value={open ? autocompleteValue : displayValue}
+          tabIndex={0}
+          onChange={(e) => {
+            setAutocompleteValue(e.target.value);
+            if (e.target.value && e.target.value !== '') {
+              const results = options?.filter((o) =>
+                o.text
+                  ?.toLowerCase()
+                  .includes(e.target.value.toLowerCase() || '')
+              );
+              setResults(results || []);
+            } else {
+              setResults([]);
+            }
+          }}
+          onFocus={() => {
+            !disabled && setOpen(true);
+          }}
+          type="text"
+          placeholder={placeholder}
+          disabled={!!disabled}
+          ref={inputRef}
+          {...otherProps}
+        />
+        <div className="md-autocomplete__input-icon">
+          <MdChevronIcon />
+        </div>
+
+        {options && options.length > 0 && (
+          <div className="md-autocomplete__dropdown">
+            {(autocompleteValue
+              ? results
+              : defaultOptions
+              ? defaultOptions
+              : []
+            ).map((option) => (
+              <button
+                key={`md-autocomplete-option-${uuid}-${option.value}`}
+                id={`md-autocomplete-option-${uuid}-${option.value}`}
+                type="button"
+                tabIndex={open ? 0 : -1}
+                className={optionClass(option)}
+                onClick={() => {
+                  open && handleOptionClick(option);
+                }}
+              >
+                <div className="md-autocomplete__dropdown-item-text">
+                  {option.text}
+                </div>
+                {isSelectedOption(option) && (
+                  <div
+                    className="md-autocomplete__dropdown-item-clear"
+                    title="Klikk for å fjerne valg"
+                  >
+                    <MdXIcon />
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </MdClickOutsideWrapper>
+
+      {error && errorText && errorText !== '' && (
+        <div className="md-autocomplete__error">{errorText}</div>
+      )}
+    </div>
+  );
+};
+
+export default MdAutocomplete;

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -174,6 +174,8 @@ const MdAutocomplete: React.FunctionComponent<MdAutocompleteProps> = ({
               ? results
               : defaultOptions
               ? defaultOptions
+              : options
+              ? options
               : []
             ).map((option) => (
               <button

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -4,6 +4,9 @@ import MdCheckboxGroup, { MdCheckboxGroupProps } from './formElements/MdCheckbox
 import MdInput, { MdInputProps } from './formElements/MdInput';
 import MdSelect, { MdSelectProps } from './formElements/MdSelect';
 import MdMultiSelect, { MdMultiSelectProps } from './formElements/MdMultiSelect';
+import MdAutocomplete, {
+  MdAutocompleteProps,
+} from './formElements/MdAutocomplete';
 import MdRadioGroup, { MdRadioGroupProps } from './formElements/MdRadioGroup';
 import MdTextArea, { MdTextAreaProps } from './formElements/MdTextArea';
 import MdFileUpload, { MdFileUploadProps } from './formElements/MdFileUpload';
@@ -132,6 +135,7 @@ export {
   MdInput,
   MdSelect,
   MdMultiSelect,
+  MdAutocomplete,
   MdRadioGroup,
   MdTextArea,
   MdFileUpload,
@@ -161,6 +165,7 @@ export {
   MdInputProps,
   MdSelectProps,
   MdMultiSelectProps,
+  MdAutocompleteProps,
   MdRadioGroupProps,
   MdTextAreaProps,
   MdFileUploadProps,

--- a/stories/Autocomplete.stories.tsx
+++ b/stories/Autocomplete.stories.tsx
@@ -1,0 +1,202 @@
+import {
+  ArgsTable,
+  Description,
+  PRIMARY_STORY,
+  Primary,
+  Stories,
+  Subtitle,
+  Title,
+} from '@storybook/addon-docs';
+import { useArgs } from '@storybook/client-api';
+import React from 'react';
+// @ts-ignore
+import Readme from '../packages/css/src/formElements/autocomplete/README.md';
+import MdAutocomplete from '../packages/react/src/formElements/MdAutocomplete';
+import MdZoomIcon from '../packages/react/src/icons/MdZoomIcon';
+
+export default {
+  title: 'Form/Autocomplete',
+  component: MdAutocomplete,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+          <Description markdown={Readme} />
+        </>
+      ),
+      description: {
+        component:
+          "A form component for single autocomplete.<br/><br/>`import { MdAutocomplete } from '@miljodirektoratet/md-react'`",
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      type: { name: 'string' },
+      description: 'The label for the autocomplete box.',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
+    defaultOptions: {
+      type: { name: 'array' },
+      description: 'Array with data objects for default autocomplete options',
+      table: {
+        type: {
+          summary:
+            "[{ value: string | number, text: 'string' }, { value: string | number, text: 'string' }, ...]",
+        },
+      },
+    },
+    options: {
+      type: { name: 'array', required: true },
+      description:
+        'Array with data objects for searchable autocomplete options',
+      table: {
+        type: {
+          summary:
+            "[{ value: string | number, text: 'string' }, { value: string | number, text: 'string' }, ...]",
+        },
+      },
+    },
+    value: {
+      type: { name: 'string | number' },
+      description:
+        'The currently selected value. This corresponds to `value` from selected `option`',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
+    id: {
+      type: { name: 'string | number' },
+      description:
+        'Id for the autocomplete box. If not set, uses a random uuid',
+      table: {
+        defaultValue: { summary: 'uuid()' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
+    disabled: {
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    size: {
+      description: 'Set size og autocomplete box',
+      options: ['large', 'medium', 'small'],
+      table: {
+        defaultValue: { summary: 'large' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'inline-radio' },
+    },
+    helpText: {
+      type: { name: 'string' },
+      description: 'Help text for the autocomplete box',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
+    error: {
+      description: 'Does autocomplete box contain error?',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    errorText: {
+      type: { name: 'string' },
+      description: 'Text to display if error',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
+    onChange: {
+      type: { name: 'function' },
+      description:
+        'The onChange handler for change events. Returns the clicked option, to handle as you please.',
+      table: {
+        type: {
+          summary: 'function',
+        },
+      },
+    },
+    inputRef: {
+      type: { name: 'Ref<HTMLButtonElement>' },
+      description:
+        "Ref to the input element that toggles the select dropdown, use for example to bring focus to the component when there's an error.",
+    },
+  },
+};
+
+const Template = (args) => {
+  const [_, updateArgs] = useArgs();
+
+  const handleChange = (option) => {
+    const newValue = args.value === option?.value ? '' : option?.value;
+    updateArgs({ ...args, value: newValue });
+  };
+
+  return (
+    <div style={{ minHeight: '300px' }}>
+      <MdAutocomplete {...args} onChange={handleChange} />
+    </div>
+  );
+};
+
+export const Autocomplete = Template.bind({});
+Autocomplete.args = {
+  label: 'Label',
+  prefixIcon: <MdZoomIcon />,
+  options: [
+    { value: 'optionA', text: 'A option' },
+    { value: 'optionAB', text: 'AB option' },
+    { value: 'optionB', text: 'B option' },
+    { value: 'optionBC', text: 'BC option' },
+  ],
+  defaultOptions: [
+    { value: 'optionA', text: 'A option' },
+    { value: 'optionB', text: 'B option' },
+  ],
+  value: 'optionA',
+  id: '',
+  disabled: false,
+  size: 'large',
+  helpText: '',
+  error: false,
+  errorText: '',
+};


### PR DESCRIPTION
## Describe your changes
Implement autocomplete component. The component allows for default visible dropdown options as well as additional searchable options. The component was made by creating a merged version of MdInput and MdSelect.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [x] If new component: Is story for component created in `stories`-folder?
- [x] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [x] If new component: Is css-file added to `packages/css/index.css`?

