### PR TITLE
Focus trap for MdModal component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/utils/MdClickOutsideWrapper.tsx
+++ b/packages/react/src/utils/MdClickOutsideWrapper.tsx
@@ -4,20 +4,31 @@ export interface MdClickOutsideWrapperProps {
   onClickOutside(e: React.MouseEvent): void;
   children: React.ReactNode;
   className?: any;
-};
+  ref?: React.ForwardedRef<HTMLDivElement>;
+}
 
-const MdClickOutsideWrapper: React.FunctionComponent<MdClickOutsideWrapperProps> = ({
-  onClickOutside,
-  children,
-  className = '',
-  ...otherProps
-}: MdClickOutsideWrapperProps) => {
-  const ref = useRef(null);
+const MdClickOutsideWrapper = React.forwardRef<
+  HTMLDivElement,
+  MdClickOutsideWrapperProps
+>(({ onClickOutside, children, className = '', ...otherProps }, ref) => {
+  const innerRef = useRef(null);
+
+  /**
+   * Combine ref from parent via props with internal ref
+   */
+  useEffect(() => {
+    if (!ref) return;
+    if (typeof ref === 'function') {
+      ref(innerRef.current);
+    } else {
+      ref.current = innerRef.current;
+    }
+  });
 
   useEffect(() => {
     const handleClickOutside = (event: React.MouseEvent) => {
       // @ts-ignore
-      if (ref.current && !ref.current?.contains(event.target)) {
+      if (innerRef.current && !innerRef.current?.contains(event.target)) {
         onClickOutside && onClickOutside(event);
       }
     };
@@ -27,13 +38,13 @@ const MdClickOutsideWrapper: React.FunctionComponent<MdClickOutsideWrapperProps>
       // @ts-ignore
       document.removeEventListener('click', handleClickOutside, true);
     };
-  }, [ onClickOutside ]);
+  }, [onClickOutside]);
 
   return (
-    <div ref={ref} className={className} {...otherProps}>
+    <div ref={innerRef} className={className} {...otherProps}>
       {children}
     </div>
   );
-};
+});
 
 export default MdClickOutsideWrapper;


### PR DESCRIPTION
## Describe your changes
When a modal is displayed, with a backdrop, it is not possible via mouse to interact with any other parts of the UI. The user is effectively trapped within the modal and has to close the modal before being able to click links, buttons, etc. on the page below.

The same should be true when using keyboard for navigation: when the modal is displayed it should not be possible to use the tab-key to get to other UI elements below the modal. Before this change, that was possible to do.

I've added a focus trap, that will make sure that when the last focusable element in the modal is reached, the next tab-keypress takes you back to the first focusable element in the modal. So it's not possible to get to the other UI elements of the page below without first closing the modal properly.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

