### PR TITLE
Bugfix on form element forward refs

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
+import MdChevronIcon from '../icons/MdChevronIcon';
 import MdXIcon from '../icons/MdXIcon';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
-import MdChevronIcon from '../icons/MdChevronIcon';
 
 interface MdAutocompleteOptionProps {
   text: string;
@@ -27,189 +27,192 @@ export interface MdAutocompleteProps {
   error?: boolean;
   errorText?: string;
   prefixIcon?: React.ReactNode;
-  inputRef?: React.Ref<HTMLInputElement>;
 }
 
-const MdAutocomplete: React.FunctionComponent<MdAutocompleteProps> = ({
-  label,
-  value,
-  options,
-  defaultOptions,
-  id = null,
-  name,
-  placeholder = 'Søk',
-  disabled = false,
-  size,
-  helpText,
-  error = false,
-  errorText,
-  prefixIcon = null,
-  onChange,
-  inputRef,
-  ...otherProps
-}: MdAutocompleteProps) => {
-  const [open, setOpen] = useState(false);
-  const [helpOpen, setHelpOpen] = useState(false);
-  const [autocompleteValue, setAutocompleteValue] = useState('');
-  const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
+const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
+  (
+    {
+      label,
+      value,
+      options,
+      defaultOptions,
+      id = null,
+      name,
+      placeholder = 'Søk',
+      disabled = false,
+      size,
+      helpText,
+      error = false,
+      errorText,
+      prefixIcon = null,
+      onChange,
+      ...otherProps
+    },
+    ref
+  ) => {
+    const [open, setOpen] = useState(false);
+    const [helpOpen, setHelpOpen] = useState(false);
+    const [autocompleteValue, setAutocompleteValue] = useState('');
+    const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
 
-  const uuid = id || uuidv4();
-  const inputId = id && id !== '' ? id : uuidv4();
+    const uuid = id || uuidv4();
+    const inputId = id && id !== '' ? id : uuidv4();
 
-  const classNames = classnames('md-autocomplete', {
-    'md-autocomplete--open': !!open,
-    'md-autocomplete--error': !!error,
-    'md-autocomplete--disabled': !!disabled,
-    'md-autocomplete--medium': size === 'medium',
-    'md-autocomplete--small': size === 'small',
-  });
-
-  const inputClassNames = classnames('md-autocomplete__input', {
-    'md-autocomplete__input--open': !!open,
-    'md-autocomplete__input--error': !!error,
-    'md-autocomplete__input--has-prefix':
-      prefixIcon !== null && prefixIcon !== '',
-  });
-
-  const selectedOption =
-    value && value !== ''
-      ? options && options.find((o) => o.value === value)
-      : '';
-
-  let displayValue = placeholder;
-  if (selectedOption && selectedOption.value) {
-    displayValue = selectedOption.text;
-  }
-  if (open) {
-    displayValue = '';
-  }
-
-  const handleOptionClick = (option: MdAutocompleteOptionProps) => {
-    onChange(option);
-    setOpen(false);
-    setAutocompleteValue('');
-  };
-
-  const isSelectedOption = (option: MdAutocompleteOptionProps) => {
-    return value && value !== '' && value == option.value;
-  };
-
-  const optionClass = (option: MdAutocompleteOptionProps) => {
-    return classnames('md-autocomplete__dropdown-item', {
-      'md-autocomplete__dropdown-item--selected': isSelectedOption(option),
+    const classNames = classnames('md-autocomplete', {
+      'md-autocomplete--open': !!open,
+      'md-autocomplete--error': !!error,
+      'md-autocomplete--disabled': !!disabled,
+      'md-autocomplete--medium': size === 'medium',
+      'md-autocomplete--small': size === 'small',
     });
-  };
 
-  return (
-    <div className={classNames}>
-      <div className="md-autocomplete__label">
-        <div>{label}</div>
+    const inputClassNames = classnames('md-autocomplete__input', {
+      'md-autocomplete__input--open': !!open,
+      'md-autocomplete__input--error': !!error,
+      'md-autocomplete__input--has-prefix':
+        prefixIcon !== null && prefixIcon !== '',
+    });
+
+    const selectedOption =
+      value && value !== ''
+        ? options && options.find((o) => o.value === value)
+        : '';
+
+    let displayValue = placeholder;
+    if (selectedOption && selectedOption.value) {
+      displayValue = selectedOption.text;
+    }
+    if (open) {
+      displayValue = '';
+    }
+
+    const handleOptionClick = (option: MdAutocompleteOptionProps) => {
+      onChange(option);
+      setOpen(false);
+      setAutocompleteValue('');
+    };
+
+    const isSelectedOption = (option: MdAutocompleteOptionProps) => {
+      return value && value !== '' && value == option.value;
+    };
+
+    const optionClass = (option: MdAutocompleteOptionProps) => {
+      return classnames('md-autocomplete__dropdown-item', {
+        'md-autocomplete__dropdown-item--selected': isSelectedOption(option),
+      });
+    };
+
+    return (
+      <div className={classNames}>
+        <div className="md-autocomplete__label">
+          <div>{label}</div>
+          {helpText && helpText !== '' && (
+            <div className="md-autocomplete__help-button">
+              <MdHelpButton
+                onClick={() => setHelpOpen(!helpOpen)}
+                expanded={helpOpen}
+              />
+            </div>
+          )}
+        </div>
+
         {helpText && helpText !== '' && (
-          <div className="md-autocomplete__help-button">
-            <MdHelpButton
-              onClick={() => setHelpOpen(!helpOpen)}
-              expanded={helpOpen}
-            />
+          <div
+            className={`md-autocomplete__help-text ${
+              helpOpen ? 'md-autocomplete__help-text--open' : ''
+            }`}
+          >
+            <MdHelpText>{helpText}</MdHelpText>
           </div>
+        )}
+
+        <MdClickOutsideWrapper
+          onClickOutside={() => setOpen(false)}
+          className="md-autocomplete__container"
+        >
+          {prefixIcon && (
+            <div
+              className={`${classnames('md-autocomplete__input__prefix', {
+                'md-autocomplete__input__prefix--disabled': !!disabled,
+              })}`}
+            >
+              {prefixIcon}
+            </div>
+          )}
+          <input
+            id={inputId}
+            className={inputClassNames}
+            value={open ? autocompleteValue : displayValue}
+            tabIndex={0}
+            onChange={(e) => {
+              setAutocompleteValue(e.target.value);
+              if (e.target.value && e.target.value !== '') {
+                const results = options?.filter((o) =>
+                  o.text
+                    ?.toLowerCase()
+                    .includes(e.target.value.toLowerCase() || '')
+                );
+                setResults(results || []);
+              } else {
+                setResults([]);
+              }
+            }}
+            onFocus={() => {
+              !disabled && setOpen(true);
+            }}
+            type="text"
+            placeholder={placeholder}
+            disabled={!!disabled}
+            ref={ref}
+            {...otherProps}
+          />
+          <div className="md-autocomplete__input-icon">
+            <MdChevronIcon />
+          </div>
+
+          {options && options.length > 0 && (
+            <div className="md-autocomplete__dropdown">
+              {(autocompleteValue
+                ? results
+                : defaultOptions
+                ? defaultOptions
+                : options
+                ? options
+                : []
+              ).map((option) => (
+                <button
+                  key={`md-autocomplete-option-${uuid}-${option.value}`}
+                  id={`md-autocomplete-option-${uuid}-${option.value}`}
+                  type="button"
+                  tabIndex={open ? 0 : -1}
+                  className={optionClass(option)}
+                  onClick={() => {
+                    open && handleOptionClick(option);
+                  }}
+                >
+                  <div className="md-autocomplete__dropdown-item-text">
+                    {option.text}
+                  </div>
+                  {isSelectedOption(option) && (
+                    <div
+                      className="md-autocomplete__dropdown-item-clear"
+                      title="Klikk for å fjerne valg"
+                    >
+                      <MdXIcon />
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </MdClickOutsideWrapper>
+
+        {error && errorText && errorText !== '' && (
+          <div className="md-autocomplete__error">{errorText}</div>
         )}
       </div>
-
-      {helpText && helpText !== '' && (
-        <div
-          className={`md-autocomplete__help-text ${
-            helpOpen ? 'md-autocomplete__help-text--open' : ''
-          }`}
-        >
-          <MdHelpText>{helpText}</MdHelpText>
-        </div>
-      )}
-
-      <MdClickOutsideWrapper
-        onClickOutside={() => setOpen(false)}
-        className="md-autocomplete__container"
-      >
-        {prefixIcon && (
-          <div
-            className={`${classnames('md-autocomplete__input__prefix', {
-              'md-autocomplete__input__prefix--disabled': !!disabled,
-            })}`}
-          >
-            {prefixIcon}
-          </div>
-        )}
-        <input
-          id={inputId}
-          className={inputClassNames}
-          value={open ? autocompleteValue : displayValue}
-          tabIndex={0}
-          onChange={(e) => {
-            setAutocompleteValue(e.target.value);
-            if (e.target.value && e.target.value !== '') {
-              const results = options?.filter((o) =>
-                o.text
-                  ?.toLowerCase()
-                  .includes(e.target.value.toLowerCase() || '')
-              );
-              setResults(results || []);
-            } else {
-              setResults([]);
-            }
-          }}
-          onFocus={() => {
-            !disabled && setOpen(true);
-          }}
-          type="text"
-          placeholder={placeholder}
-          disabled={!!disabled}
-          ref={inputRef}
-          {...otherProps}
-        />
-        <div className="md-autocomplete__input-icon">
-          <MdChevronIcon />
-        </div>
-
-        {options && options.length > 0 && (
-          <div className="md-autocomplete__dropdown">
-            {(autocompleteValue
-              ? results
-              : defaultOptions
-              ? defaultOptions
-              : options
-              ? options
-              : []
-            ).map((option) => (
-              <button
-                key={`md-autocomplete-option-${uuid}-${option.value}`}
-                id={`md-autocomplete-option-${uuid}-${option.value}`}
-                type="button"
-                tabIndex={open ? 0 : -1}
-                className={optionClass(option)}
-                onClick={() => {
-                  open && handleOptionClick(option);
-                }}
-              >
-                <div className="md-autocomplete__dropdown-item-text">
-                  {option.text}
-                </div>
-                {isSelectedOption(option) && (
-                  <div
-                    className="md-autocomplete__dropdown-item-clear"
-                    title="Klikk for å fjerne valg"
-                  >
-                    <MdXIcon />
-                  </div>
-                )}
-              </button>
-            ))}
-          </div>
-        )}
-      </MdClickOutsideWrapper>
-
-      {error && errorText && errorText !== '' && (
-        <div className="md-autocomplete__error">{errorText}</div>
-      )}
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default MdAutocomplete;

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -29,107 +29,108 @@ export interface MdInputProps {
   onKeyDown?(e: React.KeyboardEvent<HTMLInputElement>): void;
   minLength?: number;
   maxLength?: number;
-  inputRef?: React.Ref<HTMLInputElement>;
-};
-
-const MdInput: React.FunctionComponent<MdInputProps> = ({
-  label,
-  id,
-  value = '',
-  type = 'text',
-  size = 'normal',
-  placeholder,
-  disabled = false,
-  readOnly = false,
-  error = false,
-  errorText,
-  hideErrorIcon = false,
-  helpText,
-  outerWrapperClass = '',
-  suffix = undefined,
-  prefixIcon = null,
-  hideNumberArrows = false,
-  inputRef,
-  ...otherProps
-}: MdInputProps) => {
-  const [helpOpen, setHelpOpen] = useState(false);
-  const inputId = id && id !== '' ? id : uuidv4();
-
-  const classNames = classnames('md-input', {
-    'md-input--small': size === 'small',
-    'md-input--disabled': !!disabled,
-    'md-input--readonly': !!readOnly,
-    'md-input--error': !!error,
-    'md-input--has-suffix': suffix && suffix !== '',
-    'md-input--has-prefix': prefixIcon !== null && prefixIcon !== '',
-    'md-input--hide-number-arrows': !!hideNumberArrows
-  });
-
-  const wrapperClassNames = classnames('md-input__wrapper', {
-    'md-input__wrapper--small': size === 'small'
-  });
-
-  return (
-    <div className={`md-input__outer-wrapper ${outerWrapperClass}`}>
-      <div className="md-input__label">
-        {label && label !== '' &&
-          <label htmlFor={inputId}>
-            {label}
-          </label>
-        }
-        {helpText && helpText !== '' &&
-          <div className="md-input__help-button">
-            <MdHelpButton
-              onClick={() => setHelpOpen(!helpOpen)}
-              expanded={helpOpen}
-            />
-          </div>
-        }
-      </div>
-
-      {helpText && helpText !== '' &&
-        <div className={`md-input__help-text ${helpOpen ? 'md-input__help-text--open' : ''}`}>
-          <MdHelpText>{ helpText }</MdHelpText>
-        </div>
-      }
-      <div className={wrapperClassNames}>
-        {prefixIcon &&
-          <div className={`${classnames('md-input__prefix', {
-            'md-input__prefix--disabled': !!disabled
-          })}`}>
-            {prefixIcon}
-          </div>
-        }
-        <input
-          id={inputId}
-          className={classNames}
-          value={value}
-          type={type}
-          placeholder={placeholder}
-          disabled={!!disabled}
-          readOnly={!!readOnly}
-          ref={inputRef}
-          {...otherProps}
-        />
-
-        <div className="md-input__suffix">
-          {suffix &&
-            <div className="md-input__suffix-content">
-              {suffix}
-            </div>
-          }
-          {error && !hideErrorIcon &&
-            <div className="md-input__error-icon">
-              <MdWarningIcon />
-            </div>
-          }
-        </div>
-      </div>
-      {error && errorText && errorText !== '' &&
-        <div className="md-input__error">{errorText}</div>
-      }
-    </div>
-  );
 }
+
+const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
+  (
+    {
+      label,
+      id,
+      value = '',
+      type = 'text',
+      size = 'normal',
+      placeholder,
+      disabled = false,
+      readOnly = false,
+      error = false,
+      errorText,
+      hideErrorIcon = false,
+      helpText,
+      outerWrapperClass = '',
+      suffix = undefined,
+      prefixIcon = null,
+      hideNumberArrows = false,
+      ...otherProps
+    },
+    ref
+  ) => {
+    const [helpOpen, setHelpOpen] = useState(false);
+    const inputId = id && id !== '' ? id : uuidv4();
+
+    const classNames = classnames('md-input', {
+      'md-input--small': size === 'small',
+      'md-input--disabled': !!disabled,
+      'md-input--readonly': !!readOnly,
+      'md-input--error': !!error,
+      'md-input--has-suffix': suffix && suffix !== '',
+      'md-input--has-prefix': prefixIcon !== null && prefixIcon !== '',
+      'md-input--hide-number-arrows': !!hideNumberArrows,
+    });
+
+    const wrapperClassNames = classnames('md-input__wrapper', {
+      'md-input__wrapper--small': size === 'small',
+    });
+
+    return (
+      <div className={`md-input__outer-wrapper ${outerWrapperClass}`}>
+        <div className="md-input__label">
+          {label && label !== '' && <label htmlFor={inputId}>{label}</label>}
+          {helpText && helpText !== '' && (
+            <div className="md-input__help-button">
+              <MdHelpButton
+                onClick={() => setHelpOpen(!helpOpen)}
+                expanded={helpOpen}
+              />
+            </div>
+          )}
+        </div>
+
+        {helpText && helpText !== '' && (
+          <div
+            className={`md-input__help-text ${
+              helpOpen ? 'md-input__help-text--open' : ''
+            }`}
+          >
+            <MdHelpText>{helpText}</MdHelpText>
+          </div>
+        )}
+        <div className={wrapperClassNames}>
+          {prefixIcon && (
+            <div
+              className={`${classnames('md-input__prefix', {
+                'md-input__prefix--disabled': !!disabled,
+              })}`}
+            >
+              {prefixIcon}
+            </div>
+          )}
+          <input
+            id={inputId}
+            className={classNames}
+            value={value}
+            type={type}
+            placeholder={placeholder}
+            disabled={!!disabled}
+            readOnly={!!readOnly}
+            ref={ref}
+            {...otherProps}
+          />
+
+          <div className="md-input__suffix">
+            {suffix && <div className="md-input__suffix-content">{suffix}</div>}
+            {error && !hideErrorIcon && (
+              <div className="md-input__error-icon">
+                <MdWarningIcon />
+              </div>
+            )}
+          </div>
+        </div>
+        {error && errorText && errorText !== '' && (
+          <div className="md-input__error">{errorText}</div>
+        )}
+      </div>
+    );
+  }
+);
 
 export default MdInput;

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -11,172 +11,193 @@ import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 interface MdSelectOptionProps {
   text: string;
   value: string;
-};
+}
 
 export interface MdSelectProps {
-    label?: string | null;
-    options?: MdSelectOptionProps[];
-    id?: string | number | null | undefined;
-    onChange(e: MdSelectOptionProps): void;
-    name?: string;
-    value?: string | number;
-    placeholder?: string;
-    disabled?: boolean;
-    size?: string;
-    helpText?: string;
-    error?: boolean;
-    errorText?: string;
-    selectRef?: React.Ref<HTMLButtonElement>;
-};
+  label?: string | null;
+  options?: MdSelectOptionProps[];
+  id?: string | number | null | undefined;
+  onChange(e: MdSelectOptionProps): void;
+  name?: string;
+  value?: string | number;
+  placeholder?: string;
+  disabled?: boolean;
+  size?: string;
+  helpText?: string;
+  error?: boolean;
+  errorText?: string;
+}
 
-const MdSelect: React.FunctionComponent<MdSelectProps> = ({
-  label,
-  value,
-  options,
-  id = null,
-  name,
-  placeholder = 'Vennligst velg',
-  disabled = false,
-  size,
-  helpText,
-  error = false,
-  errorText,
-  onChange,
-  selectRef
-}: MdSelectProps) => {
-  const [open, setOpen] = useState(false);
-  const [helpOpen, setHelpOpen] = useState(false);
+const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
+  (
+    {
+      label,
+      value,
+      options,
+      id = null,
+      name,
+      placeholder = 'Vennligst velg',
+      disabled = false,
+      size,
+      helpText,
+      error = false,
+      errorText,
+      onChange,
+    },
+    ref
+  ) => {
+    const [open, setOpen] = useState(false);
+    const [helpOpen, setHelpOpen] = useState(false);
 
-  const uuid = id || uuidv4();
+    const uuid = id || uuidv4();
 
-  const classNames = classnames('md-select', {
-    'md-select--open': !!open,
-    'md-select--error': !!error,
-    'md-select--disabled': !!disabled,
-    'md-select--medium': size === 'medium',
-    'md-select--small': size === 'small'
-  });
+    const classNames = classnames('md-select', {
+      'md-select--open': !!open,
+      'md-select--error': !!error,
+      'md-select--disabled': !!disabled,
+      'md-select--medium': size === 'medium',
+      'md-select--small': size === 'small',
+    });
 
-  const selectedOption = value && value !== '' ? options && options.find(o => o.value === value) : '';
+    const selectedOption =
+      value && value !== ''
+        ? options && options.find((o) => o.value === value)
+        : '';
 
-  let displayValue = placeholder;
-  if (selectedOption && selectedOption.value) {
-    displayValue = selectedOption.text;
-  }
-  if (open) {
-    displayValue = '';
-  }
-
-  useEffect(() => {
-    document.addEventListener("keydown", onKeyDown, false);
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown, false);
+    let displayValue = placeholder;
+    if (selectedOption && selectedOption.value) {
+      displayValue = selectedOption.text;
     }
-  });
-
-  const onKeyDown = (e: any) => {
     if (open) {
-      const reg = /[a-z\Wæøå]+/igm;
-      const key = e.key;
-      if(key && reg.test(key) && key.length === 1) {
-        const option = options?.find(o => (o.text?.startsWith(key.toLowerCase()) || o.text?.startsWith(key.toUpperCase())));
-        if (option) {
-          /* Find corresponding button */
-          const button = document.getElementById(`md-select-option-${uuid}-${option.value}`);
-          if (button) {
-            button.focus();
+      displayValue = '';
+    }
+
+    useEffect(() => {
+      document.addEventListener('keydown', onKeyDown, false);
+
+      return () => {
+        document.removeEventListener('keydown', onKeyDown, false);
+      };
+    });
+
+    const onKeyDown = (e: any) => {
+      if (open) {
+        const reg = /[a-z\Wæøå]+/gim;
+        const key = e.key;
+        if (key && reg.test(key) && key.length === 1) {
+          const option = options?.find(
+            (o) =>
+              o.text?.startsWith(key.toLowerCase()) ||
+              o.text?.startsWith(key.toUpperCase())
+          );
+          if (option) {
+            /* Find corresponding button */
+            const button = document.getElementById(
+              `md-select-option-${uuid}-${option.value}`
+            );
+            if (button) {
+              button.focus();
+            }
           }
         }
       }
-    }
-  }
+    };
 
-  const handleOptionClick = (option: MdSelectOptionProps) => {
-    onChange(option);
-    setOpen(false);
-  }
+    const handleOptionClick = (option: MdSelectOptionProps) => {
+      onChange(option);
+      setOpen(false);
+    };
 
-  const isSelectedOption = (option: MdSelectOptionProps) => {
-    return value && value !== '' && value == option.value;
-  }
+    const isSelectedOption = (option: MdSelectOptionProps) => {
+      return value && value !== '' && value == option.value;
+    };
 
-  const buttonClasseNames = classnames('md-select__button', {
-    'md-select__button--open': !!open,
-    'md-select__button--error': !!error
-  });
-
-  const optionClass = (option: MdSelectOptionProps) => {
-    return classnames('md-select__dropdown-item', {
-      'md-select__dropdown-item--selected': isSelectedOption(option)
+    const buttonClasseNames = classnames('md-select__button', {
+      'md-select__button--open': !!open,
+      'md-select__button--error': !!error,
     });
-  }
 
-  return (
-    <div className={classNames}>
-      <div className="md-select__label">
-        <div>{label}</div>
-        {helpText && helpText !== '' &&
-          <div className="md-select__help-button">
-            <MdHelpButton
-              onClick={() => setHelpOpen(!helpOpen)}
-              expanded={helpOpen}
-            />
-          </div>
-        }
-      </div>
+    const optionClass = (option: MdSelectOptionProps) => {
+      return classnames('md-select__dropdown-item', {
+        'md-select__dropdown-item--selected': isSelectedOption(option),
+      });
+    };
 
-      {helpText && helpText !== '' &&
-        <div className={`md-select__help-text ${helpOpen ? 'md-select__help-text--open' : ''}`}>
-          <MdHelpText>{ helpText }</MdHelpText>
+    return (
+      <div className={classNames}>
+        <div className="md-select__label">
+          <div>{label}</div>
+          {helpText && helpText !== '' && (
+            <div className="md-select__help-button">
+              <MdHelpButton
+                onClick={() => setHelpOpen(!helpOpen)}
+                expanded={helpOpen}
+              />
+            </div>
+          )}
         </div>
-      }
 
-      <MdClickOutsideWrapper
-        onClickOutside={() => setOpen(false)}
-        className='md-select__container'
-      >
-        <button
-          className={buttonClasseNames}
-          type='button'
-          tabIndex={0}
-          onClick={() => !disabled && setOpen(!open)}
-          ref={selectRef}
+        {helpText && helpText !== '' && (
+          <div
+            className={`md-select__help-text ${
+              helpOpen ? 'md-select__help-text--open' : ''
+            }`}
+          >
+            <MdHelpText>{helpText}</MdHelpText>
+          </div>
+        )}
+
+        <MdClickOutsideWrapper
+          onClickOutside={() => setOpen(false)}
+          className="md-select__container"
         >
-          <div className="md-select__button-text">{displayValue}</div>
-          <div className="md-select__button-icon">
-            <MdChevronIcon />
-          </div>
-        </button>
+          <button
+            className={buttonClasseNames}
+            type="button"
+            tabIndex={0}
+            onClick={() => !disabled && setOpen(!open)}
+            ref={ref}
+          >
+            <div className="md-select__button-text">{displayValue}</div>
+            <div className="md-select__button-icon">
+              <MdChevronIcon />
+            </div>
+          </button>
 
-        {options && options.length > 0 &&
-          <div className="md-select__dropdown">
-            {options.map(option => (
-              <button
-                key={`md-select-option-${uuid}-${option.value}`}
-                id={`md-select-option-${uuid}-${option.value}`}
-                type='button'
-                tabIndex={open ? 0: -1}
-                className={optionClass(option)}
-                onClick={() => open && handleOptionClick(option)}
-              >
-                <div className="md-select__dropdown-item-text">{option.text}</div>
-                {isSelectedOption(option) &&
-                  <div className="md-select__dropdown-item-clear" title="Klikk for å fjerne valg">
-                    <MdXIcon />
+          {options && options.length > 0 && (
+            <div className="md-select__dropdown">
+              {options.map((option) => (
+                <button
+                  key={`md-select-option-${uuid}-${option.value}`}
+                  id={`md-select-option-${uuid}-${option.value}`}
+                  type="button"
+                  tabIndex={open ? 0 : -1}
+                  className={optionClass(option)}
+                  onClick={() => open && handleOptionClick(option)}
+                >
+                  <div className="md-select__dropdown-item-text">
+                    {option.text}
                   </div>
-                }
-              </button>
-            ))}
-          </div>
-        }
-      </MdClickOutsideWrapper>
+                  {isSelectedOption(option) && (
+                    <div
+                      className="md-select__dropdown-item-clear"
+                      title="Klikk for å fjerne valg"
+                    >
+                      <MdXIcon />
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </MdClickOutsideWrapper>
 
-      {error && errorText && errorText !== '' &&
-        <div className="md-select__error">{errorText}</div>
-      }
-    </div>
-  );
-};
+        {error && errorText && errorText !== '' && (
+          <div className="md-select__error">{errorText}</div>
+        )}
+      </div>
+    );
+  }
+);
 
 export default MdSelect;


### PR DESCRIPTION
## Describe your changes
Ref-props introduced in pr #38 didn't work as intended. Here's a fix, that makes use of React's forwardRef-functionality to expose the correct DOM-node ref to parent.

## Checklist before requesting a review
- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?

