### PR TITLE
fix: deploy to npm failed due to missing uuidv4() type

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.14",
-    "@types/uuid": "^9.0.6",
+    "@types/uuid": "^9.0.7",
     "typescript": "^4.7.3"
   },
   "files": [

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -117,7 +117,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
       )}
 
       <div
-        id={groupId}
+        id={`md-checkboxgroup_${groupId}`}
         aria-describedby={helpText && helpText !== '' ? `md-checkboxgroup_help-text_${groupId}` : undefined}
         className={optionsClassNames}
       >

--- a/packages/react/src/formElements/MdRadioGroup.tsx
+++ b/packages/react/src/formElements/MdRadioGroup.tsx
@@ -115,8 +115,8 @@ const MdRadioGroup: React.FunctionComponent<MdRadioGroupProps> = ({
       )}
 
       <div
-        aria-describedby={helpText && helpText !== '' ? `md-radiogroup_help-text_${radioId}` : undefined}
         id={`md-radiogroup_${radioId}`}
+        aria-describedby={helpText && helpText !== '' ? `md-radiogroup_help-text_${radioId}` : undefined}
         className={optionsClassNames}
       >
         {options &&


### PR DESCRIPTION
# Describe your changes

Untyped uuid() use caused issues in the build pipeline because type checking is not able to work when uuid() is defined as "any". Hopefully it is fixed now.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
