### PR TITLE
fix: storybook issue caused by eslint formatting

### DIFF
--- a/stories/ChipsStories/FilterChip.stories.tsx
+++ b/stories/ChipsStories/FilterChip.stories.tsx
@@ -1,6 +1,6 @@
+import { Title, Subtitle, Description, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
 import React from 'react';
-import { Title, Subtitle, Description, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 // @ts-ignore
 import Readme from '../../packages/css/src/chips/README.md';
 
@@ -12,17 +12,19 @@ export default {
   component: MdFilterChip,
   parameters: {
     docs: {
-      page: () => {return (
-        <>
-          <Title />
-          <Subtitle />
-          <Description />
-          <Primary />
-          <ArgsTable story={PRIMARY_STORY} />
-          <Stories />
-          <Description markdown={Readme} />
-        </>
-      )},
+      page: () => {
+        return (
+          <>
+            <Title />
+            <Subtitle />
+            <Description />
+            <Primary />
+            <ArgsTable story={PRIMARY_STORY} />
+            <Stories />
+            <Description markdown={Readme} />
+          </>
+        );
+      },
       description: {
         component:
           "A chip component used for filters. Requires an onClick handler.<br/><br/>`import { MdFilterChip } from '@miljodirektoratet/md-react'`",
@@ -97,15 +99,15 @@ const Template = args => {
   const [_, updateArgs] = useArgs();
 
   const handleClick = () => {
-    updateArgs({ ...args active: !args.active });
+    updateArgs({ ...args, active: !args.active });
   };
 
   return (
     <MdFilterChip
       {...args}
       prefixIcon={args.prefixIcon ? <MdUserIcon /> : null}
-      onClick={e => {
-        handleClick(e);
+      onClick={() => {
+        handleClick();
       }}
     />
   );

--- a/stories/ChipsStories/InputChip.stories.tsx
+++ b/stories/ChipsStories/InputChip.stories.tsx
@@ -1,6 +1,6 @@
+import { Title, Subtitle, Description, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 import { useArgs } from '@storybook/client-api';
 import React from 'react';
-import { Title, Subtitle, Description, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 // @ts-ignore
 import Readme from '../../packages/css/src/chips/README.md';
 
@@ -12,17 +12,19 @@ export default {
   component: MdInputChip,
   parameters: {
     docs: {
-      page: () => {return (
-        <>
-          <Title />
-          <Subtitle />
-          <Description />
-          <Primary />
-          <ArgsTable story={PRIMARY_STORY} />
-          <Stories />
-          <Description markdown={Readme} />
-        </>
-      )},
+      page: () => {
+        return (
+          <>
+            <Title />
+            <Subtitle />
+            <Description />
+            <Primary />
+            <ArgsTable story={PRIMARY_STORY} />
+            <Stories />
+            <Description markdown={Readme} />
+          </>
+        );
+      },
       description: {
         component:
           "A chip component. Requires an onClick handler. In this example clicks toggle active state.<br/><br/>`import { MdInputChip } from '@miljodirektoratet/md-react'`",
@@ -117,15 +119,15 @@ const Template = args => {
   const [_, updateArgs] = useArgs();
 
   const handleClick = () => {
-    updateArgs({ ...args active: !args.active });
+    updateArgs({ ...args, active: !args.active });
   };
 
   return (
     <MdInputChip
       {...args}
       prefixIcon={args.prefixIcon ? <MdUserIcon /> : null}
-      onClick={e => {
-        handleClick(e);
+      onClick={() => {
+        handleClick();
       }}
     />
   );


### PR DESCRIPTION
# Describe your changes

Previous prettier/eslint formatting of the repo did in fact mess something up - in the storybook filter-chip stories. Fixed it.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
