### PR TITLE
Add a11y-features to dropdown-components

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -183,6 +183,11 @@
   z-index: 2;
 }
 
+/* Focus state */
+.md-autocomplete__input:focus {
+  border: 2px solid var(--mdPrimaryColor);
+}
+
 /* open + error */
 .md-autocomplete--open.md-autocomplete--error .md-autocomplete__input {
   border-color: var(--mdErrorColor);

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -184,7 +184,7 @@
 }
 
 /* Focus state */
-.md-autocomplete__input:focus {
+.md-autocomplete:not(.md-autocomplete--open) .md-autocomplete__input:focus {
   border: 2px solid var(--mdPrimaryColor);
 }
 

--- a/packages/css/src/formElements/fileupload/fileupload.css
+++ b/packages/css/src/formElements/fileupload/fileupload.css
@@ -74,3 +74,7 @@
 .md-fileupload__actions > * + * {
   margin-left: 1em;
 }
+
+.md-fileupload__button {
+  margin-left: 4px !important;
+}

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -190,6 +190,11 @@
   gap: 0.5em;
 }
 
+/* Focus state */
+.md-multiselect__button:focus {
+  border: 2px solid var(--mdPrimaryColor);
+}
+
 /* Open state */
 .md-multiselect--open .md-multiselect__button {
   border-top: 2px solid var(--mdPrimaryColor);

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -190,11 +190,6 @@
   gap: 0.5em;
 }
 
-/* Focus state */
-.md-multiselect__button:focus {
-  border: 2px solid var(--mdPrimaryColor);
-}
-
 /* Open state */
 .md-multiselect--open .md-multiselect__button {
   border-top: 2px solid var(--mdPrimaryColor);
@@ -202,8 +197,10 @@
   border-left: 2px solid var(--mdPrimaryColor);
 }
 
-.md-multiselect__button--open {
+.md-multiselect__button:not(.md-multiselect__button--open):focus,
+.md-multiselect__button:not(.md-multiselect__button--open):focus-within {
   padding: calc(1em - 1px);
+  border: 2px solid var(--mdPrimaryColor);
 }
 
 .md-multiselect__dropdown--open {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -158,6 +158,11 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             className={inputClassNames}
             value={open ? autocompleteValue : displayValue}
             tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                setOpen(!open);
+              }
+            }}
             onChange={e => {
               setAutocompleteValue(e.target.value);
               if (e.target.value && e.target.value !== '') {

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -108,7 +108,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     return (
       <div className={classNames}>
         <div className="md-autocomplete__label">
-          {label && label !== '' && <label htmlFor={uuid}>{label}</label>}
+          {label && label !== '' && <label htmlFor={`md-autocomplete_${uuid}`}>{label}</label>}
           {helpText && helpText !== '' && (
             <div className="md-autocomplete__help-button">
               <MdHelpButton

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -153,7 +153,13 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             </div>
           )}
           <input
+            role="listbox"
             id={`md-autocomplete_${uuid}`}
+            aria-activedescendant={
+              selectedOption
+                ? `md-autocomplete-option-${uuid}-${(selectedOption as MdAutocompleteOptionProps)?.value}`
+                : undefined
+            }
             aria-describedby={helpText && helpText !== '' ? `md-autocomplete_help-text_${uuid}` : undefined}
             className={inputClassNames}
             value={open ? autocompleteValue : displayValue}
@@ -192,6 +198,8 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
               {(autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : []).map(option => {
                 return (
                   <button
+                    role="option"
+                    aria-selected={!!isSelectedOption(option)}
                     key={`md-autocomplete-option-${uuid}-${option.value}`}
                     id={`md-autocomplete-option-${uuid}-${option.value}`}
                     type="button"

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -158,11 +158,6 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             aria-expanded={open}
             aria-controls="md-autocomplete_dropdown_${uuid}"
             id={`md-autocomplete_${uuid}`}
-            aria-activedescendant={
-              selectedOption
-                ? `md-autocomplete-option-${uuid}-${(selectedOption as MdAutocompleteOptionProps)?.value}`
-                : undefined
-            }
             aria-describedby={helpText && helpText !== '' ? `md-autocomplete_help-text_${uuid}` : undefined}
             className={inputClassNames}
             value={open ? autocompleteValue : displayValue}

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -153,7 +153,9 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             </div>
           )}
           <input
-            role="listbox"
+            role="combobox"
+            aria-expanded={open}
+            aria-controls="md-autocomplete_dropdown_${uuid}"
             id={`md-autocomplete_${uuid}`}
             aria-activedescendant={
               selectedOption
@@ -194,7 +196,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
           </div>
 
           {options && options.length > 0 && (
-            <div className="md-autocomplete__dropdown">
+            <div role="listbox" id={'md-autocomplete__dropdown_${uuid}'} className="md-autocomplete__dropdown">
               {(autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : []).map(option => {
                 return (
                   <button

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
+import useDropdown from '../hooks/useDropdown';
 import MdChevronIcon from '../icons/MdChevronIcon';
 import MdXIcon from '../icons/MdXIcon';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
@@ -53,6 +54,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [helpOpen, setHelpOpen] = useState(false);
     const [autocompleteValue, setAutocompleteValue] = useState('');
     const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
+    useDropdown(open, setOpen);
 
     const uuid = id && id !== '' ? id : uuidv4();
 

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
@@ -54,7 +54,8 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [helpOpen, setHelpOpen] = useState(false);
     const [autocompleteValue, setAutocompleteValue] = useState('');
     const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
-    useDropdown(open, setOpen);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    useDropdown(dropdownRef, open, setOpen);
 
     const uuid = id && id !== '' ? id : uuidv4();
 
@@ -136,6 +137,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
         )}
 
         <MdClickOutsideWrapper
+          ref={dropdownRef}
           onClickOutside={() => {
             return setOpen(false);
           }}

--- a/packages/react/src/formElements/MdFileUpload.tsx
+++ b/packages/react/src/formElements/MdFileUpload.tsx
@@ -102,6 +102,7 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
         <div className="md-fileupload__droparea-content">
           Dropp {imagesOnly ? 'et bilde' : 'en fil'} her eller
           <button
+            className="md-fileupload__button"
             type="button"
             onClick={() => {
               return inputRef.current?.click();

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -209,6 +209,11 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
                     disabled={!!disabled}
                     data-value={option.value}
                     data-text={option.text}
+                    onKeyDown={(e: React.ChangeEvent & React.KeyboardEvent) => {
+                      if (e.key === 'Enter') {
+                        return handleOptionClick(e);
+                      }
+                    }}
                     onChange={(e: React.ChangeEvent) => {
                       return handleOptionClick(e);
                     }}

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -178,7 +178,9 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
         className="md-multiselect__dropdown-wrapper"
       >
         <button
-          role="listbox"
+          role="combobox"
+          aria-expanded={open}
+          aria-controls="md-multiselect_dropdown_${uuid}"
           type="button"
           aria-labelledby={`md-multiselect_label_${uuid}`}
           id={`md-multiselect_${uuid}`}
@@ -199,7 +201,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
         </button>
 
         {options && options.length > 0 && (
-          <div className={dropDownClassNames}>
+          <div role="listbox" id={'md-multiselect_dropdown_${uuid}'} className={dropDownClassNames}>
             {options.map(option => {
               return (
                 <div key={`checkbox_key_${uuid}_${option.value}`} className={optionClass(option)}>

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -140,7 +140,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   return (
     <div className={classNames}>
       <div className="md-multiselect__label">
-        {label && label !== '' && <div>{label}</div>}
+        {label && label !== '' && <div id={`md-multiselect_label_${uuid}`}>{label}</div>}
 
         {helpText && helpText !== '' && (
           <div className="md-multiselect__help-button">
@@ -178,6 +178,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
       >
         <button
           type="button"
+          aria-labelledby={`md-multiselect_label_${uuid}`}
           id={`md-multiselect_${uuid}`}
           aria-describedby={helpText && helpText !== '' ? `md-multiselect_help-text_${uuid}` : undefined}
           className={buttonClassNames}

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import MdInputChip from '../chips/MdInputChip';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
+import useDropdown from '../hooks/useDropdown';
 import MdChevronIcon from '../icons/MdChevronIcon';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 import MdCheckbox from './MdCheckbox';
@@ -50,6 +51,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   const uuid = id || uuidv4();
   const [open, setOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  useDropdown(open, setOpen);
 
   let hasMultipleSelected = false;
 

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -140,7 +140,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   return (
     <div className={classNames}>
       <div className="md-multiselect__label">
-        {label && label !== '' && <div id={`md-multiselect_label_${uuid}`}>{label}</div>}
+        {label && label !== '' && <label id={`md-multiselect_label_${uuid}`}>{label}</label>}
 
         {helpText && helpText !== '' && (
           <div className="md-multiselect__help-button">

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -19,7 +19,6 @@ interface MdMultiSelectOptionProps {
 export interface MdMultiSelectProps {
   label?: string | null;
   options?: MdMultiSelectOptionProps[];
-  onChange?(_e: React.ChangeEvent): void;
   selected?: MdMultiSelectOptionProps[];
   placeholder?: string;
   disabled?: boolean;
@@ -31,6 +30,7 @@ export interface MdMultiSelectProps {
   closeOnSelect?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   id?: any;
+  onChange?(_e: React.ChangeEvent): void;
 }
 
 const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
@@ -45,8 +45,9 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   errorText,
   showChips = false,
   closeOnSelect = false,
-  onChange,
   id,
+  onChange,
+  ...otherProps
 }: MdMultiSelectProps) => {
   const uuid = id || uuidv4();
   const [open, setOpen] = useState(false);
@@ -138,7 +139,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   };
 
   return (
-    <div className={classNames}>
+    <div className={classNames} {...otherProps}>
       <div className="md-multiselect__label">
         {label && label !== '' && <label id={`md-multiselect_label_${uuid}`}>{label}</label>}
 

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -141,7 +141,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   return (
     <div className={classNames} {...otherProps}>
       <div className="md-multiselect__label">
-        {label && label !== '' && <label id={`md-multiselect_label_${uuid}`}>{label}</label>}
+        {label && label !== '' && <div id={`md-multiselect_label_${uuid}`}>{label}</div>}
 
         {helpText && helpText !== '' && (
           <div className="md-multiselect__help-button">
@@ -178,6 +178,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
         className="md-multiselect__dropdown-wrapper"
       >
         <button
+          role="listbox"
           type="button"
           aria-labelledby={`md-multiselect_label_${uuid}`}
           id={`md-multiselect_${uuid}`}
@@ -203,6 +204,8 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
               return (
                 <div key={`checkbox_key_${uuid}_${option.value}`} className={optionClass(option)}>
                   <MdCheckbox
+                    role="option"
+                    aria-selected={optionIsChecked(option)}
                     label={option.text}
                     tabIndex={open ? 0 : -1}
                     checked={!!optionIsChecked(option)}

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdInputChip from '../chips/MdInputChip';
@@ -51,7 +51,8 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
   const uuid = id || uuidv4();
   const [open, setOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  useDropdown(open, setOpen);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  useDropdown(dropdownRef, open, setOpen);
 
   let hasMultipleSelected = false;
 
@@ -169,6 +170,7 @@ const MdMultiSelect: React.FunctionComponent<MdMultiSelectProps> = ({
       )}
 
       <MdClickOutsideWrapper
+        ref={dropdownRef}
         onClickOutside={() => {
           return setOpen(false);
         }}

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -128,7 +128,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     return (
       <div className={classNames} {...otherProps}>
         <div className="md-select__label">
-          <label id={`md-select_label_${uuid}`}>{label}</label>
+          {label && label !== '' && <div id={`md-select_label_${uuid}`}>{label}</div>}
           {helpText && helpText !== '' && (
             <div className="md-select__help-button">
               <MdHelpButton
@@ -165,10 +165,14 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
         >
           <button
             aria-labelledby={`md-select_label_${uuid}`}
+            role="listbox"
             id={`md-select_${uuid}`}
             aria-describedby={helpText && helpText !== '' ? `md-select_help-text_${uuid}` : undefined}
             className={buttonClassNames}
             type="button"
+            aria-activedescendant={
+              selectedOption ? `md-select-option-${uuid}-${(selectedOption as MdSelectOptionProps)?.value}` : undefined
+            }
             tabIndex={0}
             onClick={() => {
               return !disabled && setOpen(!open);
@@ -186,6 +190,8 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
               {options.map(option => {
                 return (
                   <button
+                    role="option"
+                    aria-selected={!!isSelectedOption(option)}
                     key={`md-select-option-${uuid}-${option.value}`}
                     id={`md-select-option-${uuid}-${option.value}`}
                     type="button"

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -85,8 +85,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
       };
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onKeyDown = (e: any) => {
+    const onKeyDown = (e: KeyboardEvent) => {
       if (open) {
         const reg = /[a-z\Wæøå]+/gim;
         const key = e.key;

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
@@ -48,7 +48,8 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
   ) => {
     const [open, setOpen] = useState(false);
     const [helpOpen, setHelpOpen] = useState(false);
-    useDropdown(open, setOpen);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    useDropdown(dropdownRef, open, setOpen);
 
     const uuid = id || uuidv4();
 
@@ -156,6 +157,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
         )}
 
         <MdClickOutsideWrapper
+          ref={dropdownRef}
           onClickOutside={() => {
             return setOpen(false);
           }}

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -127,7 +127,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     return (
       <div className={classNames}>
         <div className="md-select__label">
-          <div id={`md-select_label_${uuid}`}>{label}</div>
+          <label id={`md-select_label_${uuid}`}>{label}</label>
           {helpText && helpText !== '' && (
             <div className="md-select__help-button">
               <MdHelpButton

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
@@ -76,6 +76,34 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     if (open) {
       displayValue = '';
     }
+
+    useEffect(() => {
+      document.addEventListener('keydown', onKeyDown, false);
+
+      return () => {
+        document.removeEventListener('keydown', onKeyDown, false);
+      };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onKeyDown = (e: any) => {
+      if (open) {
+        const reg = /[a-z\Wæøå]+/gim;
+        const key = e.key;
+        if (key && reg.test(key) && key.length === 1) {
+          const option = options?.find(o => {
+            return o.text?.startsWith(key.toLowerCase()) || o.text?.startsWith(key.toUpperCase());
+          });
+          if (option) {
+            /* Find corresponding button */
+            const button = document.getElementById(`md-select-option-${uuid}-${option.value}`);
+            if (button) {
+              button.focus();
+            }
+          }
+        }
+      }
+    };
 
     const handleOptionClick = (option: MdSelectOptionProps) => {
       onChange(option);

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -172,9 +172,6 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
             aria-describedby={helpText && helpText !== '' ? `md-select_help-text_${uuid}` : undefined}
             className={buttonClassNames}
             type="button"
-            aria-activedescendant={
-              selectedOption ? `md-select-option-${uuid}-${(selectedOption as MdSelectOptionProps)?.value}` : undefined
-            }
             tabIndex={0}
             onClick={() => {
               return !disabled && setOpen(!open);

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -127,7 +127,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     return (
       <div className={classNames}>
         <div className="md-select__label">
-          <div>{label}</div>
+          <div id={`md-select_label_${uuid}`}>{label}</div>
           {helpText && helpText !== '' && (
             <div className="md-select__help-button">
               <MdHelpButton
@@ -163,6 +163,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
           className="md-select__container"
         >
           <button
+            aria-labelledby={`md-select_label_${uuid}`}
             id={`md-select_${uuid}`}
             aria-describedby={helpText && helpText !== '' ? `md-select_help-text_${uuid}` : undefined}
             className={buttonClassNames}

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
@@ -76,34 +76,6 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     if (open) {
       displayValue = '';
     }
-
-    useEffect(() => {
-      document.addEventListener('keydown', onKeyDown, false);
-
-      return () => {
-        document.removeEventListener('keydown', onKeyDown, false);
-      };
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onKeyDown = (e: any) => {
-      if (open) {
-        const reg = /[a-z\Wæøå]+/gim;
-        const key = e.key;
-        if (key && reg.test(key) && key.length === 1) {
-          const option = options?.find(o => {
-            return o.text?.startsWith(key.toLowerCase()) || o.text?.startsWith(key.toUpperCase());
-          });
-          if (option) {
-            /* Find corresponding button */
-            const button = document.getElementById(`md-select-option-${uuid}-${option.value}`);
-            if (button) {
-              button.focus();
-            }
-          }
-        }
-      }
-    };
 
     const handleOptionClick = (option: MdSelectOptionProps) => {
       onChange(option);

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -164,8 +164,10 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
           className="md-select__container"
         >
           <button
+            role="combobox"
+            aria-expanded={open}
+            aria-controls="md-select_dropdown_${uuid}"
             aria-labelledby={`md-select_label_${uuid}`}
-            role="listbox"
             id={`md-select_${uuid}`}
             aria-describedby={helpText && helpText !== '' ? `md-select_help-text_${uuid}` : undefined}
             className={buttonClassNames}
@@ -186,7 +188,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
           </button>
 
           {options && options.length > 0 && (
-            <div className="md-select__dropdown">
+            <div role="listbox" className="md-select__dropdown" id={'md-select_dropdown_${uuid}'}>
               {options.map(option => {
                 return (
                   <button

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
+import useDropdown from '../hooks/useDropdown';
 import MdChevronIcon from '../icons/MdChevronIcon';
 import MdXIcon from '../icons/MdXIcon';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
@@ -47,6 +48,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
   ) => {
     const [open, setOpen] = useState(false);
     const [helpOpen, setHelpOpen] = useState(false);
+    useDropdown(open, setOpen);
 
     const uuid = id || uuidv4();
 

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -18,7 +18,6 @@ export interface MdSelectProps {
   label?: string | null;
   options?: MdSelectOptionProps[];
   id?: string | number | null | undefined;
-  onChange(_e: MdSelectOptionProps): void;
   name?: string;
   value?: string | number;
   placeholder?: string;
@@ -27,6 +26,7 @@ export interface MdSelectProps {
   helpText?: string;
   error?: boolean;
   errorText?: string;
+  onChange(_e: MdSelectOptionProps): void;
 }
 
 const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
@@ -43,6 +43,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
       error = false,
       errorText,
       onChange,
+      ...otherProps
     },
     ref,
   ) => {
@@ -125,7 +126,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     };
 
     return (
-      <div className={classNames}>
+      <div className={classNames} {...otherProps}>
         <div className="md-select__label">
           <label id={`md-select_label_${uuid}`}>{label}</label>
           {helpText && helpText !== '' && (

--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 
 const focusableHtmlElements = 'button, [tabindex]';
 
-export default function useDropdown(open: boolean, setOpen: (_open: boolean) => void) {
-  const ref = useRef<HTMLDivElement>(null);
-
+export default function useDropdown(
+  ref: React.RefObject<HTMLDivElement>,
+  open: boolean,
+  setOpen: (_open: boolean) => void,
+) {
   const onKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       const button = document.getElementById('language-switcher-toggle');

--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const focusableHtmlElements = 'button, [tabindex]';
+
+export default function useDropdown(open: boolean, setOpen: (_open: boolean) => void) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      const button = document.getElementById('language-switcher-toggle');
+      button?.focus();
+      document.removeEventListener('keydown', onKeyDown, false);
+      setOpen(false);
+    }
+
+    if (e.key === 'Tab') {
+      if (e.shiftKey) {
+        return;
+      }
+      const focusableElements = ref.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);
+      if (!focusableElements || !document.activeElement) {
+        return;
+      }
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (document.activeElement.getAttribute('id') === lastElement.id) {
+        document.removeEventListener('keydown', onKeyDown, false);
+        setOpen(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('keydown', onKeyDown, false);
+    }
+  }, [open, onKeyDown]);
+}

--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react';
 
-const focusableHtmlElements = 'button, [tabindex]';
+const focusableHtmlElements = 'button, input, [tabindex]';
 
 export default function useDropdown(
   ref: React.RefObject<HTMLDivElement>,
@@ -8,8 +8,10 @@ export default function useDropdown(
   setOpen: (_open: boolean) => void,
 ) {
   const onKeyDown = useCallback((e: KeyboardEvent) => {
+    const focusableElements = ref.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);
+
     if (e.key === 'Escape') {
-      const button = document.getElementById('language-switcher-toggle');
+      const button = focusableElements?.[0];
       button?.focus();
       document.removeEventListener('keydown', onKeyDown, false);
       setOpen(false);
@@ -19,7 +21,6 @@ export default function useDropdown(
       if (e.shiftKey) {
         return;
       }
-      const focusableElements = ref.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);
       if (!focusableElements || !document.activeElement) {
         return;
       }

--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -24,7 +24,7 @@ export default function useDropdown(
       if (!focusableElements || !document.activeElement) {
         return;
       }
-      const lastElement = focusableElements[focusableElements.length - 1];
+      const lastElement = focusableElements[Math.max(0, focusableElements.length - 1)];
 
       if (document.activeElement.getAttribute('id') === lastElement.id) {
         document.removeEventListener('keydown', onKeyDown, false);

--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -11,8 +11,8 @@ export default function useDropdown(
     const focusableElements = ref.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);
 
     if (e.key === 'Escape') {
-      const button = focusableElements?.[0];
-      button?.focus();
+      const element = focusableElements?.[0];
+      element?.focus();
       document.removeEventListener('keydown', onKeyDown, false);
       setOpen(false);
     }


### PR DESCRIPTION
# Describe your changes

- Make the dropdown components MdSelect, MdMultiSelect, and MdAutocomplete accessible: close on escape press and re-focus initial element, tab through content closes dropdown
- Add focus states for MdMulstiSelect and MdAutocomplete
- Fix MdMultiSelect enter press not selecting the focused element

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
