### PR TITLE
fix: default button type to all buttons

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/chips/MdFilterChip.tsx
+++ b/packages/react/src/chips/MdFilterChip.tsx
@@ -31,6 +31,7 @@ const MdFilterChip: React.FunctionComponent<MdFilterChipProps> = ({
 
   return (
     <button
+      type="button"
       aria-pressed={active}
       className={buttonClassNames}
       id={String(chipId) || undefined}

--- a/packages/react/src/chips/MdInputChip.tsx
+++ b/packages/react/src/chips/MdInputChip.tsx
@@ -35,7 +35,13 @@ const MdInputChip: React.FunctionComponent<MdInputChipProps> = ({
   });
 
   return (
-    <button className={buttonClassNames} id={String(chipId) || undefined} disabled={disabled} {...otherProps}>
+    <button
+      type="button"
+      className={buttonClassNames}
+      id={String(chipId) || undefined}
+      disabled={disabled}
+      {...otherProps}
+    >
       {prefixIcon && (
         <div aria-hidden="true" className="md-chip__left-icon">
           {prefixIcon}

--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -59,6 +59,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
 
       {!!closable && onClose && (
         <button
+          type="button"
           aria-label="Lukk"
           className="md-alert-message__button"
           onClick={e => {

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -23,7 +23,6 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
   children,
   heading = '',
   headingIcon,
-
   open = false,
   error = false,
   className = '',
@@ -97,7 +96,9 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
         <div className="md-modal__content">
           <MdClickOutsideWrapper
             onClickOutside={e => {
-              if (closeOnOutsideClick) closeModal(e);
+              if (closeOnOutsideClick) {
+                closeModal(e);
+              }
             }}
             className="md-modal__inner-wrapper"
             ref={modalRef}
@@ -108,6 +109,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
                 {heading}
               </div>
               <button
+                type="button"
                 className="md-modal__close-button"
                 onClick={e => {
                   closeModal(e);

--- a/packages/react/src/tabs/MdTabTitle.tsx
+++ b/packages/react/src/tabs/MdTabTitle.tsx
@@ -24,6 +24,7 @@ const MdTabTitle: React.FunctionComponent<MdTabTitleProps> = ({
   return (
     <li>
       <button
+        type="button"
         className={classNames}
         onClick={() => {
           return !disabled && setSelectedTab(index);


### PR DESCRIPTION
# Describe your changes

Add type="button" to all buttons that did not have the property specified. Buttons without a type can cause issues in some browsers or when used inside a form (unwanted submits).

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
