### PR TITLE
fix: console react errors due to conditionally run hooks

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -37,17 +37,6 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
     },
     className,
   );
-
-  const closeModal = (e: React.MouseEvent) => {
-    if (onClose) {
-      onClose(e);
-    }
-  };
-
-  if (!open) {
-    return null;
-  }
-
   const modalRef = useRef<HTMLDivElement>(null);
 
   /**
@@ -88,6 +77,16 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
       return document.removeEventListener('keydown', keyListener);
     };
   }, []);
+
+  const closeModal = (e: React.MouseEvent) => {
+    if (onClose) {
+      onClose(e);
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
# Describe your changes

Ordering of hooks and `if (!open) return null` caused React errors in the console as hooks were being conditionally run (which isn't allowed). 

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
