### PR TITLE
fix: components with onclicks should be buttons

### DIFF
--- a/md-components.code-workspace
+++ b/md-components.code-workspace
@@ -27,7 +27,7 @@
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"]
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -5,7 +5,6 @@ export interface MdLinkProps {
   children?: string | React.ReactNode;
   href?: string;
   onClick?(_e: React.MouseEvent): void;
-  className?: string;
 }
 
 const MdLink: React.FunctionComponent<MdLinkProps> = ({

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -1,18 +1,28 @@
 import classnames from 'classnames';
 import React from 'react';
 
-export interface MdLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface MdLinkProps {
   children?: string | React.ReactNode;
   href?: string;
   onClick?(_e: React.MouseEvent): void;
+  className?: string;
 }
 
-const MdLink: React.FunctionComponent<MdLinkProps> = ({ children, ...otherProps }: MdLinkProps) => {
+const MdLink: React.FunctionComponent<MdLinkProps> = ({
+  href,
+  children,
+  onClick,
+  ...otherProps
+}: MdLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
   const classNames = classnames('md-link', otherProps.className);
-  return (
-    <a {...otherProps} className={classNames}>
+  return href ? (
+    <a href={href} {...otherProps} className={classNames}>
       {children}
     </a>
+  ) : (
+    <button type="button" onClick={onClick} {...otherProps} className={classNames}>
+      {children}
+    </button>
   );
 };
 

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -37,17 +37,6 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
     },
     className,
   );
-
-  const closeModal = (e: React.MouseEvent) => {
-    if (onClose) {
-      onClose(e);
-    }
-  };
-
-  if (!open) {
-    return null;
-  }
-
   const modalRef = useRef<HTMLDivElement>(null);
 
   /**
@@ -88,6 +77,16 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
       return document.removeEventListener('keydown', keyListener);
     };
   }, []);
+
+  const closeModal = (e: React.MouseEvent) => {
+    if (onClose) {
+      onClose(e);
+    }
+  };
+
+  if (!open) {
+    return null;
+  }
 
   return (
     <>

--- a/packages/react/src/tiles/MdTile.tsx
+++ b/packages/react/src/tiles/MdTile.tsx
@@ -15,7 +15,7 @@ export interface MdTileProps {
 const MdTile: React.FC<MdTileProps> = ({
   heading,
   description,
-  href = '#',
+  href,
   disabled = false,
   icon = null,
   preventDefault = false,
@@ -34,9 +34,8 @@ const MdTile: React.FC<MdTileProps> = ({
     }
   };
 
-  return (
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a className={classNames} href={disabled ? '' : href} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
+  const content = (
+    <>
       <div className="md-tile__content">
         {icon && icon !== '' && <div className="md-tile__content-icon">{icon}</div>}
         <div className="md-tile__content-text">
@@ -44,11 +43,20 @@ const MdTile: React.FC<MdTileProps> = ({
           {description && description !== '' && <div className="md-tile__content-description">{description}</div>}
         </div>
       </div>
-
       <div className="md-tile__arrow">
         <MdChevronIcon height={25} />
       </div>
+    </>
+  );
+
+  return href ? (
+    <a className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
+      {content}
     </a>
+  ) : (
+    <button disabled={disabled} type="button" className={classNames} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
+      {content}
+    </button>
   );
 };
 

--- a/packages/react/src/tiles/MdTileVertical.tsx
+++ b/packages/react/src/tiles/MdTileVertical.tsx
@@ -17,7 +17,7 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   description,
   size,
   disabled = false,
-  href = '#',
+  href,
   icon = null,
   preventDefault = false,
   onClick,
@@ -37,19 +37,26 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
     }
   };
 
-  return (
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a className={classNames} href={disabled ? '' : href} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
-      <div className="md-tile-vertical__content">
-        {icon && icon !== '' && <div className="md-tile-vertical__content-icon">{icon}</div>}
-        <div className="md-tile-vertical__content-text">
-          <div className="md-tile-vertical__content-heading">{heading}</div>
-          {description && description !== '' && (
-            <div className="md-tile-vertical__content-description">{description}</div>
-          )}
-        </div>
+  const content = (
+    <div className="md-tile-vertical__content">
+      {icon && icon !== '' && <div className="md-tile-vertical__content-icon">{icon}</div>}
+      <div className="md-tile-vertical__content-text">
+        <div className="md-tile-vertical__content-heading">{heading}</div>
+        {description && description !== '' && (
+          <div className="md-tile-vertical__content-description">{description}</div>
+        )}
       </div>
+    </div>
+  );
+
+  return href ? (
+    <a className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
+      {content}
     </a>
+  ) : (
+    <button disabled={disabled} type="button" className={classNames} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
+      {content}
+    </button>
   );
 };
 


### PR DESCRIPTION
# Describe your changes

Using anchor tags as buttons is not recommended. It causes issues such as not being able to tab to the button. Refactored MdLink, MdTile and MdTileVertical to conditionally render <button or <a depending on the input props.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
