### PR TITLE
fix: incomplete typing of props for MdLink

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -7,7 +7,9 @@ export interface MdLinkProps {
   onClick?(_e: React.MouseEvent): void;
 }
 
-const MdLink: React.FunctionComponent<MdLinkProps> = ({
+const MdLink: React.FunctionComponent<
+  MdLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({
   href,
   children,
   onClick,


### PR DESCRIPTION
# Describe your changes

Previous merge of changes to MdLink had incomplete typing causing ts-warning inside projects using the library.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
