### PR TITLE
Fix for MdRadioGroup absolute positioning

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/radiogroup/radiogroup.css
+++ b/packages/css/src/formElements/radiogroup/radiogroup.css
@@ -42,6 +42,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  position: relative;
 }
 
 .md-radiogroup .md-radiogroup__options--vertical .md-radiogroup-option {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdRadioGroup.tsx
+++ b/packages/react/src/formElements/MdRadioGroup.tsx
@@ -122,15 +122,15 @@ const MdRadioGroup: React.FunctionComponent<MdRadioGroupProps> = ({
           options.map(option => {
             return (
               <label
-                htmlFor={`radio_${radioGroupId}_${option.text}`}
+                htmlFor={`radio_${radioGroupId}_${option.id}`}
                 key={`radio_${radioGroupId}_${option.id}`}
                 className="md-radiogroup-option"
               >
-                <span className="md-radiogroup-option__check-area" id={`dot_${radioGroupId}_${option.text}`}>
+                <span className="md-radiogroup-option__check-area" id={`dot_${radioGroupId}_${option.id}`}>
                   {optionIsSelected(option.id) && <span className="md-radiogroup-option__selected-dot" />}
                 </span>
                 <input
-                  id={`radio_${radioGroupId}_${option.text}`}
+                  id={`radio_${radioGroupId}_${option.id}`}
                   type="radio"
                   value={option.id}
                   checked={optionIsSelected(option.id)}


### PR DESCRIPTION
# Describe your changes

The individual radio inputs of MdRadioGroup are absolutely positioned, without having a parent element within the component as relatively positioned. This resulted in weird positioning behaviour in a real life application since the position then became relative to an element further up the DOM, outside of the MdRadioGroup component itself.

Also used option.id when concatenating the options id-prop, instead of option.text which is more likely to be something more than plain text or number. (In my case the option.text-prop was a ReactNode/JSX element, which resulted in an id that looked like `radio_customGroupName_[object: Object]`

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
