### PR TITLE
fix: missing styling on MdLink when rendered as a button

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/link/link.css
+++ b/packages/css/src/link/link.css
@@ -1,7 +1,11 @@
 .md-link {
   color: var(--mdPrimaryColor);
+  background-color: transparent;
+  border: none;
   cursor: pointer;
   font-family: 'Open sans';
+  font-weight: 500;
+  font-size: 16px;
   text-decoration: underline;
 }
 

--- a/stories/Link.stories.tsx
+++ b/stories/Link.stories.tsx
@@ -43,7 +43,7 @@ export default {
   },
 };
 
-function clickHandler(event: React.MouseEvent<HTMLInputElement>) {
+function clickHandler(event: React.MouseEvent) {
   event.preventDefault();
   event.stopPropagation();
 }


### PR DESCRIPTION
# Describe your changes

When refactoring MdLink previously, I forgot to fix the styling of the component when it was rendered as a button. It should look the same as when rendered as an anchor tag now.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
