### PR TITLE
fix: missing styling on MdTile and MdTileVertical when rendered as buttons

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/tile/tile.css
+++ b/packages/css/src/tile/tile.css
@@ -1,6 +1,6 @@
 /* HORIZONTAL TILES */
 .md-tile {
-  padding: 1.5em;
+  padding: 26px;
   border: 1px solid var(--mdGreyColor60);
   background-color: var(--mdPrimaryColor10);
   color: var(--mdGreyColor);
@@ -18,6 +18,7 @@
   border: 1px solid var(--mdPrimaryColor);
   background-color: var(--mdPrimaryColor20);
   transition: all 0.15s ease-in-out;
+  cursor: pointer;
 }
 
 .md-tile:not(.md-tile--disabled):focus {
@@ -52,10 +53,13 @@
 
 .md-tile__content-heading {
   font-size: 20px;
+  align-items: flex-start;
+  display: flex;
 }
 
 .md-tile__content-description {
   margin-top: 1em;
+  font-size: 16px;
 }
 
 .md-tile__arrow {
@@ -100,6 +104,7 @@
 .md-tile-vertical:hover {
   border: 1px solid var(--mdPrimaryColor);
   background-color: var(--mdPrimaryColor20);
+  cursor: pointer;
   transition: all 0.15s ease-in-out;
 }
 
@@ -114,15 +119,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 2em;
+  padding: 32px;
 }
 
 .md-tile-vertical--small .md-tile-vertical__content {
-  padding: 1.5em;
+  padding: 26px;
 }
 
 .md-tile-vertical--large .md-tile-vertical__content {
-  padding: 3em;
+  padding: 40px;
 }
 
 .md-tile-vertical__content-text {
@@ -149,4 +154,5 @@
 
 .md-tile-vertical__content-description {
   margin-top: 1em;
+  font-size: 16px;
 }


### PR DESCRIPTION
# Describe your changes

Previous refactor caused additional styles to need to be applied when the components are rendered as buttons.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
