### PR TITLE
fix: bugs in CSS styles for form elements and modal

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -1,7 +1,6 @@
 .md-autocomplete {
   font-family: 'Open sans';
-  width: 634px;
-  max-width: 100%;
+  width: 100%;
 }
 
 .md-autocomplete--medium {

--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -177,5 +177,5 @@
 .md-input.md-input--hide-number-arrows::-webkit-inner-spin-button {
   appearance: none;
   -webkit-appearance: none;
-  margin: 0;
+  margin: 1px;
 }

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -1,7 +1,6 @@
 .md-multiselect {
   font-family: 'Open sans';
-  width: 634px;
-  max-width: 100%;
+  width: 100%;
 }
 
 .md-multiselect--medium {

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -1,7 +1,6 @@
 .md-select {
   font-family: 'Open sans';
-  width: 634px;
-  max-width: 100%;
+  width: 100%;
 }
 
 .md-select--medium {

--- a/packages/css/src/help/help.css
+++ b/packages/css/src/help/help.css
@@ -1,7 +1,6 @@
 /* HELP BUTTON */
 .md-helpbutton {
   display: flex;
-  flex-grow: 1;
   position: relative;
   background-color: transparent;
   padding: 0;

--- a/packages/css/src/modal/modal.css
+++ b/packages/css/src/modal/modal.css
@@ -47,7 +47,8 @@
 .md-modal__header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  padding-top: 1em;
   font-size: 1.43em;
 }
 
@@ -58,7 +59,8 @@
 }
 
 .md-modal__close-button {
-  padding: 2em;
+  padding-right: 2em;
+  padding-left: 2em;
   background: transparent;
   border: 0;
   border-radius: 0;


### PR DESCRIPTION
# Describe your changes

- Set base width of dropdown-components to 100% so they will fit the content they are placed in.
- Set margin 1px to input field when number arrows are disabled to avoid it from shifting on active.
- Fix CSS for modal header so the close button doesn't get misaligned when the header is more than one line.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
