### PR TITLE
Tabs fiks

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/tabs/tabs.css
+++ b/packages/css/src/tabs/tabs.css
@@ -18,12 +18,27 @@
 }
 
 .md-tabs-container ul li .md-tabs-button {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+
   font-size: 1em;
   font-weight: 400;
   padding: 13px 24px 12px 24px;
   border: 0;
   background-color: transparent;
   border-bottom: 1px solid var(--mdGreyColor80);
+}
+.md-tabs-container ul li .md-tabs-button::after {
+  content: attr(data-text);
+  content: attr(data-text) / '';
+  height: 0;
+  visibility: hidden;
+  overflow: hidden;
+  user-select: none;
+  pointer-events: none;
+  font-weight: 600;
 }
 
 .md-tabs-container ul li .md-tabs-button.md-tabs-button--disabled {

--- a/packages/css/src/tabs/tabs.css
+++ b/packages/css/src/tabs/tabs.css
@@ -20,12 +20,10 @@
 .md-tabs-container ul li .md-tabs-button {
   font-size: 1em;
   font-weight: 400;
-  padding: 13px 24px 13px 24px;
+  padding: 13px 24px 12px 24px;
   border: 0;
   background-color: transparent;
   border-bottom: 1px solid var(--mdGreyColor80);
-  transition: border 0.1s linear, background 0.1s linear, margin 0.1s linear;
-  margin-bottom: 3px;
 }
 
 .md-tabs-container ul li .md-tabs-button.md-tabs-button--disabled {
@@ -36,10 +34,9 @@
 
 .md-tabs-container ul li .md-tabs-button.md-tabs-button--selected {
   font-weight: 600;
+  padding: 13px 24px 9px 24px;
   border-bottom: 4px solid var(--mdPrimaryColor80);
-  margin-bottom: 0px;
 }
-
 .md-tabs-container ul li .md-tabs-button:not(.md-tabs-button--disabled):hover {
   background-color: var(--mdPrimaryColor20);
   cursor: pointer;
@@ -47,6 +44,7 @@
 
 .md-tabs-container ul li .md-tabs-button:not(.md-tabs-button--disabled):focus {
   outline: 2px solid var(--mdPrimaryColor);
+  outline-offset: -2px;
   background-color: var(--mdPrimaryColor20);
   cursor: pointer;
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/tabs/MdTabTitle.tsx
+++ b/packages/react/src/tabs/MdTabTitle.tsx
@@ -30,6 +30,7 @@ const MdTabTitle: React.FunctionComponent<MdTabTitleProps> = ({
           return !disabled && setSelectedTab(index);
         }}
         tabIndex={disabled ? -1 : 0}
+        data-text={title}
       >
         {title}
       </button>


### PR DESCRIPTION
# Describe your changes

Fikser stylingen for tabs. Gjør også at fokus ikke forskyver andre tabs fordi text-weight endres.

pakket og testet lokalt i Luftmålinger prosjektet.


https://github.com/miljodir/md-components/assets/21305389/aaf8bbdb-798a-4d10-b2a8-c65018bca3e7




## Checklist before requesting a review

- [X] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
