### PR TITLE
Feature/display checkboxes in columns

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/checkboxgroup/README.md
+++ b/packages/css/src/formElements/checkboxgroup/README.md
@@ -20,7 +20,7 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
     <MdHelpText>{helpText}</MdHelpText>
   </div>
 
-  <div class="md-checkboxgroup__options [md-checkboxgroup__options--vertical]">
+  <div class="md-checkboxgroup__options [md-checkboxgroup__options--vertical] [md-checkboxgroup__options--grid]">
     <!-- Here we use the designsystem react components for checkbox, see structure for these separately -->
     <MdCheckbox />
     <MdCheckbox />

--- a/packages/css/src/formElements/checkboxgroup/checkboxgroup.css
+++ b/packages/css/src/formElements/checkboxgroup/checkboxgroup.css
@@ -38,6 +38,11 @@
   flex-direction: column;
 }
 
+.md-checkboxgroup .md-checkboxgroup__options--columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+}
+
 .md-checkboxgroup__error {
   color: var(--mdErrorColor);
   font-size: 0.88em;

--- a/packages/css/src/formElements/checkboxgroup/checkboxgroup.css
+++ b/packages/css/src/formElements/checkboxgroup/checkboxgroup.css
@@ -38,9 +38,9 @@
   flex-direction: column;
 }
 
-.md-checkboxgroup .md-checkboxgroup__options--columns {
+.md-checkboxgroup .md-checkboxgroup__options--grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  grid-template-columns: repeat(2, minmax(max-content, 1fr));
 }
 
 .md-checkboxgroup__error {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -1,12 +1,11 @@
 import classnames from 'classnames';
+
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 import MdCheckbox from './MdCheckbox';
 import type { ChangeEvent } from 'react';
-
 export interface MdCheckboxGroupOptionProps {
   value: string | number;
   text?: string | number;
@@ -19,6 +18,7 @@ export interface MdCheckboxGroupProps {
   id?: string | number;
   disabled?: boolean;
   direction?: string;
+  wrap?: boolean;
   className?: string;
   error?: string;
   helpText?: string;
@@ -34,6 +34,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
   id,
   disabled = false,
   direction,
+  wrap,
   className = '',
   error,
   helpText,
@@ -55,6 +56,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
 
   const optionsClassNames = classnames('md-checkboxgroup__options', {
     'md-checkboxgroup__options--vertical': direction === 'vertical',
+    'md-checkboxgroup__options--columns': wrap,
   });
 
   const optionIsSelected = (option: MdCheckboxGroupOptionProps) => {

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -17,8 +17,7 @@ export interface MdCheckboxGroupProps {
   label?: string;
   id?: string | number;
   disabled?: boolean;
-  direction?: string;
-  wrap?: boolean;
+  direction?: 'horizontal' | 'vertical' | 'grid';
   className?: string;
   error?: string;
   helpText?: string;
@@ -34,7 +33,6 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
   id,
   disabled = false,
   direction,
-  wrap,
   className = '',
   error,
   helpText,
@@ -56,7 +54,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
 
   const optionsClassNames = classnames('md-checkboxgroup__options', {
     'md-checkboxgroup__options--vertical': direction === 'vertical',
-    'md-checkboxgroup__options--columns': wrap,
+    'md-checkboxgroup__options--grid': direction === 'grid',
   });
 
   const optionIsSelected = (option: MdCheckboxGroupOptionProps) => {

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -18,6 +18,7 @@ export interface MdCheckboxGroupProps {
   id?: string | number;
   disabled?: boolean;
   direction?: 'horizontal' | 'vertical' | 'grid';
+  columns?: number;
   className?: string;
   error?: string;
   helpText?: string;
@@ -33,6 +34,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
   id,
   disabled = false,
   direction,
+  columns = 2,
   className = '',
   error,
   helpText,
@@ -121,6 +123,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
         id={String(checkboxGroupId) || undefined}
         aria-describedby={helpText && helpText !== '' ? `md-checkboxgroup_help-text_${checkboxGroupId}` : undefined}
         className={optionsClassNames}
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(max-content, 1fr))` }}
       >
         {options.map(option => {
           return (

--- a/stories/CheckboxGroup.stories.tsx
+++ b/stories/CheckboxGroup.stories.tsx
@@ -124,6 +124,15 @@ export default {
       },
       action: 'Change',
     },
+    wrap: {
+      type: { name: 'boolean' },
+      description: 'Wrap options into columns when there is limited space horizontally.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -182,4 +191,5 @@ CheckboxGroup.args = {
   direction: 'horizontal',
   helpText: 'This is a help text!',
   error: '',
+  wrap: true,
 };

--- a/stories/CheckboxGroup.stories.tsx
+++ b/stories/CheckboxGroup.stories.tsx
@@ -83,7 +83,7 @@ export default {
     direction: {
       type: { name: 'string' },
       description: 'The direction for checkboxes in group.',
-      options: ['horizontal', 'vertical'],
+      options: ['horizontal', 'vertical', 'grid'],
       table: {
         defaultValue: { summary: 'horizontal' },
         type: {
@@ -123,15 +123,6 @@ export default {
         },
       },
       action: 'Change',
-    },
-    wrap: {
-      type: { name: 'boolean' },
-      description: 'Wrap options into columns when there is limited space horizontally.',
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      control: { type: 'boolean' },
     },
   },
 };
@@ -191,5 +182,4 @@ CheckboxGroup.args = {
   direction: 'horizontal',
   helpText: 'This is a help text!',
   error: '',
-  wrap: true,
 };

--- a/stories/CheckboxGroup.stories.tsx
+++ b/stories/CheckboxGroup.stories.tsx
@@ -124,6 +124,17 @@ export default {
       },
       action: 'Change',
     },
+    columns: {
+      type: { name: 'number' },
+      description: 'Number of columns in options grid',
+      table: {
+        defaultValue: { summary: 2 },
+        type: {
+          summary: 'number',
+        },
+      },
+      control: { type: 'number' },
+    },
   },
 };
 
@@ -182,4 +193,5 @@ CheckboxGroup.args = {
   direction: 'horizontal',
   helpText: 'This is a help text!',
   error: '',
+  columns: 3,
 };


### PR DESCRIPTION
# Describe your changes

Instead of just listing the checkbox group options either horizontally or vertically, we have a requirement to be able to display them over two columns. This pr introduces a third direction choice resulting in this:

![image](https://github.com/miljodir/md-components/assets/108116520/d63bff05-ee29-4f39-af8c-a63d2a499c45)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
