### PR TITLE
Chips tabs

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/tabs/MdTabTitle.tsx
+++ b/packages/react/src/tabs/MdTabTitle.tsx
@@ -1,5 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
+import MdInputChip from '../chips/MdInputChip';
+import type { ReactNode } from 'react';
 
 export interface MdTabTitleProps {
   title: string;
@@ -7,6 +9,8 @@ export interface MdTabTitleProps {
   disabled?: boolean;
   selectedTab: number;
   setSelectedTab: (_index: number) => void;
+  chips?: boolean;
+  chipsPrefixIcon?: ReactNode;
 }
 
 const MdTabTitle: React.FunctionComponent<MdTabTitleProps> = ({
@@ -15,11 +19,30 @@ const MdTabTitle: React.FunctionComponent<MdTabTitleProps> = ({
   disabled = false,
   selectedTab,
   setSelectedTab,
+  chips,
+  chipsPrefixIcon,
 }: MdTabTitleProps) => {
   const classNames = classnames('md-tabs-button', {
     'md-tabs-button--selected': selectedTab === index,
     'md-tabs-button--disabled': !!disabled,
   });
+
+  if (chips) {
+    return (
+      <li>
+        <MdInputChip
+          hideCloseIcon
+          label={title}
+          disabled={disabled}
+          active={selectedTab === index}
+          onClick={() => {
+            return !disabled && setSelectedTab(index);
+          }}
+          prefixIcon={selectedTab === index && chipsPrefixIcon}
+        />
+      </li>
+    );
+  }
 
   return (
     <li>

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -1,14 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from 'react';
 import MdTabTitle from './MdTabTitle';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 export interface MdTabsProps {
   children: ReactElement[];
   initialTab?: number;
+  chips?: boolean;
+  chipsPrefixIcon?: ReactNode;
 }
 
-const MdTabs: React.FunctionComponent<MdTabsProps> = ({ children, initialTab = 0 }: MdTabsProps) => {
+const MdTabs: React.FunctionComponent<MdTabsProps> = ({
+  children,
+  initialTab = 0,
+  chips = false,
+  chipsPrefixIcon = false,
+}: MdTabsProps) => {
   const [selectedTab, setSelectedTab] = useState(initialTab);
 
   const tabs = children instanceof Array ? children : [children];
@@ -25,6 +32,8 @@ const MdTabs: React.FunctionComponent<MdTabsProps> = ({ children, initialTab = 0
               disabled={item.props.disabled}
               selectedTab={selectedTab}
               setSelectedTab={setSelectedTab}
+              chips={chips}
+              chipsPrefixIcon={chipsPrefixIcon}
             />
           );
         })}

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { Title, Subtitle, Description, Markdown, Controls, Primary } from '@storybook/addon-docs';
 import React from 'react';
 import Readme from '../packages/css/src/tabs/README.md';
+import MdCheckIcon from '../packages/react/src/icons/MdCheckIcon';
 import MdTab from '../packages/react/src/tabs/MdTab';
 import MdTabs from '../packages/react/src/tabs/MdTabs';
 import type { Args } from '@storybook/react';
@@ -53,12 +54,39 @@ export default {
       },
       control: { type: 'number' },
     },
+    chips: {
+      type: { name: 'boolean' },
+      description: 'Use chips instead of buttons for the tab titles.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    chipsPrefixIcon: {
+      type: { name: 'ReactNode' },
+      description:
+        'Prefix icon to apply before chip label if active. Will render a 16px x 16px container with icon passed.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'DomElement | image | ReactNode',
+        },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
 const Template = (args: Args) => {
   return (
-    <MdTabs initialTab={args.initialTab}>
+    <MdTabs
+      initialTab={args.initialTab}
+      chips={args.chips}
+      chipsPrefixIcon={args.chipsPrefixIcon ? <MdCheckIcon /> : null}
+    >
       <MdTab title="Tab 1">
         <div style={{ fontSize: '20px', marginBottom: '.5em' }}>This is the first tab</div>
         <div>
@@ -83,4 +111,6 @@ export const Tabs = Template.bind({});
 Tabs.args = {
   disabled: false,
   initialTab: 0,
+  chips: false,
+  chipsPrefixIcon: false,
 };


### PR DESCRIPTION
# Describe your changes

Chips knapper for tabs. Mulighet for å vise ikon når chip er aktiv.

![image](https://github.com/miljodir/md-components/assets/21305389/2e4b9a23-5012-474d-825b-a72dad843ac9)
![image](https://github.com/miljodir/md-components/assets/21305389/b09dc734-370b-4b02-8c92-eca0ce1cbce6)

## Checklist before requesting a review

- [X] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
