### PR TITLE
Accessibility on MdModal

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-react",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "React-komponenter for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./dist/index.js",

--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 export interface MdLinkProps {
   children?: string | React.ReactNode;
@@ -7,24 +7,27 @@ export interface MdLinkProps {
   onClick?(_e: React.MouseEvent): void;
 }
 
-const MdLink: React.FunctionComponent<
+const MdLink = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
   MdLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>
-> = ({
-  href,
-  children,
-  onClick,
-  ...otherProps
-}: MdLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+>(({ href, children, onClick, ...otherProps }, ref) => {
   const classNames = classnames('md-link', otherProps.className);
   return href ? (
-    <a href={href} {...otherProps} className={classNames}>
+    <a href={href} {...otherProps} className={classNames} ref={ref as React.ForwardedRef<HTMLAnchorElement>}>
       {children}
     </a>
   ) : (
-    <button type="button" onClick={onClick} {...otherProps} className={classNames}>
+    <button
+      type="button"
+      onClick={onClick}
+      {...otherProps}
+      className={classNames}
+      ref={ref as React.ForwardedRef<HTMLButtonElement>}
+    >
       {children}
     </button>
   );
-};
+});
 
+MdLink.displayName = 'MdLink';
 export default MdLink;

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -119,6 +119,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
                 onClick={e => {
                   closeModal(e);
                 }}
+                aria-label="Lukk"
               >
                 <MdXIcon className="md-modal__close-button-icon" />
               </button>

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -17,7 +17,7 @@ export interface MdModalProps {
   error?: boolean;
   className?: string;
   closeOnOutsideClick?: boolean;
-  onClose?(_e: React.MouseEvent): void;
+  onClose?(_e?: React.MouseEvent): void;
 }
 
 const MdModal: React.FunctionComponent<MdModalProps> = ({
@@ -64,6 +64,11 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
           }
         }
       }
+      if (event.key === 'Escape' || event.key === 'Esc') {
+        if (onClose) {
+          onClose();
+        }
+      }
     };
 
     document.addEventListener('keydown', keyListener);
@@ -92,7 +97,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
   return (
     <>
       <div className="md-modal__overlay" />
-      <div className={classNames}>
+      <div className={classNames} role="dialog" aria-modal={true} aria-label={heading}>
         <div className="md-modal__content">
           <MdClickOutsideWrapper
             onClickOutside={e => {


### PR DESCRIPTION
# Describe your changes

Added functionality to MdModal to fulfill the accessibility requirements of a dialog:
- role "dialog"
- aria-modal "true"
- aria-label describing the dialog contents
- allow closing of the modal using Escape-key

Also added forwardRef to MdLink, to be able to focus on a link-component. Specifically to be able to bring focus back to the correct place after closing a MdModal.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
