### PR TITLE
Added missing storybook description for AccordionItem

### DIFF
--- a/stories/AccordionItem.stories.tsx
+++ b/stories/AccordionItem.stories.tsx
@@ -53,6 +53,17 @@ export default {
       },
       control: { type: 'text' },
     },
+    expanded: {
+      type: { name: 'boolean' },
+      description: 'Determines if the accordion is expanded. If not present, component handles expand/collapse internally.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
     theme: {
       type: { name: 'string' },
       description: 'Color theme for accordion.',


### PR DESCRIPTION
Adding missing storybook-description for 'expanded' prop of AccordionItem

'expanded' already existed as a prop in AccordionItem, but was not mentioned in the storybook
