### PR TITLE
fix: add same padding as other inputs

### DIFF
--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -20,7 +20,7 @@
   display: flex;
   align-items: flex-end;
   font-weight: 600;
-  padding-bottom: 0.25em;
+  padding-bottom: 0.5em;
 }
 
 .md-autocomplete__label > * + * {

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -15,7 +15,7 @@
   display: flex;
   align-items: flex-end;
   font-weight: 600;
-  padding-bottom: 0.25em;
+  padding-bottom: 0.5em;
 }
 
 .md-multiselect__label > * + * {

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -19,7 +19,7 @@
   display: flex;
   align-items: flex-end;
   font-weight: 600;
-  padding-bottom: 0.25em;
+  padding-bottom: 0.5em;
 }
 
 .md-select__label > * + * {


### PR DESCRIPTION
# Describe your changes

Padding between select-box and label is now the same as other input types

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
