### PR TITLE
fix: add missing padding under dropdown helptexts

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miljodirektoratet/md-css",
-  "version": "1.0.37",
+  "version": "1.0.36",
   "description": "CSS for Miljødirektoratet",
   "author": "Miljødirektoratet",
   "main": "./src/index.css",

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -125,6 +125,7 @@
 
 .md-autocomplete__help-text--open {
   padding-top: 0.5em;
+  padding-bottom: 0.5em;
   max-height: 2000px;
   transition: max-height 0.5s ease-in;
 }

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -99,6 +99,7 @@
 
 .md-multiselect__help-text--open {
   padding-top: 0.5em;
+  padding-bottom: 0.5em;
   max-height: 2000px;
   transition: max-height 0.5s ease-in;
 }

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -103,6 +103,7 @@
 
 .md-select__help-text--open {
   padding-top: 0.5em;
+  padding-bottom: 0.5em;
   max-height: 2000px;
   transition: max-height 0.5s ease-in;
 }


### PR DESCRIPTION
# Describe your changes

Add padding under help texts for dropdown components where it was missing.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
