### PR TITLE
fix: autocomplete off, z-index dropdowns, input error margin

### DIFF
--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -134,6 +134,7 @@
   position: absolute;
   max-height: 0;
   overflow: hidden;
+  z-index: -1;
   opacity: 0;
   transition: max-height 0.5s ease-in-out;
   width: calc(100% - 4px); /* Full width minus border-width */

--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -137,6 +137,7 @@
 .md-input__error-icon {
   width: 20px;
   height: 20px;
+  margin-left: 0.5em;
   color: var(--mdErrorColor);
 }
 

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -110,7 +110,7 @@
 
 .md-multiselect__dropdown {
   position: absolute;
-  z-index: 99;
+  z-index: -1;
   width: calc(100% - 4px);
   max-height: 0;
   overflow: hidden;
@@ -242,6 +242,7 @@
 .md-multiselect__dropdown--open {
   max-height: 350px;
   overflow-y: auto;
+  z-index: 2;
   opacity: 1;
   border: 2px solid var(--mdPrimaryColor80);
   box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -112,6 +112,7 @@
   position: absolute;
   max-height: 0;
   overflow: hidden;
+  z-index: -1;
   opacity: 0;
   transition: max-height 0.5s ease-in-out;
   width: calc(100% - 4px); /* Full width minus border-width */

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -163,6 +163,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             </div>
           )}
           <input
+            autoComplete="off"
             role="combobox"
             aria-expanded={open}
             aria-controls={`md-autocomplete_dropdown_${autocompleteId}`}


### PR DESCRIPTION
# Describe your changes

Fix z-index bugs with dropdown-components, turn off autocomplete for MdAutocomplete, and add margin to input error icon.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
