### PR TITLE
Fixed responsiveness of inputs and modal

### DIFF
--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -4,11 +4,11 @@
 }
 
 .md-autocomplete--medium {
-  width: 440px;
+  max-width: 440px;
 }
 
 .md-autocomplete--small {
-  width: 260px;
+  max-width: 260px;
 }
 
 .md-autocomplete__container {

--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -3,6 +3,10 @@
   font-size: 16px;
 }
 
+.md-input__outer-wrapper--small {
+  max-width: 336px;
+}
+
 .md-input {
   padding: 1em 2em 1em 1em;
   max-width: 100%;

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -4,11 +4,11 @@
 }
 
 .md-multiselect--medium {
-  width: 440px;
+  max-width: 440px;
 }
 
 .md-multiselect--small {
-  width: 260px;
+  max-width: 260px;
 }
 
 .md-multiselect__label {

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -4,11 +4,11 @@
 }
 
 .md-select--medium {
-  width: 440px;
+  max-width: 440px;
 }
 
 .md-select--small {
-  width: 260px;
+  max-width: 260px;
 }
 
 .md-select__container {

--- a/packages/css/src/modal/modal.css
+++ b/packages/css/src/modal/modal.css
@@ -40,6 +40,14 @@
   box-shadow: 8px 8px 16px var(--mdGreyColor60);
 }
 
+.md-modal__inner-wrapper--small {
+  width: 40vw;
+  height: 40vh;
+
+  display: flex;
+  flex-direction: column;
+}
+
 .md-modal--error .md-modal__inner-wrapper {
   border: 2px solid var(--mdErrorColor);
 }
@@ -74,4 +82,12 @@
 
 .md-modal__content-inner {
   padding-right: 2em;
+  flex-grow: 1;
+}
+
+/* Media */
+@media (max-width: 768px) {
+  .md-modal__inner-wrapper--small {
+    width: 80vw;
+  }
 }

--- a/packages/css/src/modal/modal.css
+++ b/packages/css/src/modal/modal.css
@@ -89,5 +89,6 @@
 @media (max-width: 768px) {
   .md-modal__inner-wrapper--small {
     width: 80vw;
+    height: 60vh;
   }
 }

--- a/packages/css/src/stepper/README.md
+++ b/packages/css/src/stepper/README.md
@@ -13,7 +13,7 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
       <!--  Start of step -->
       <div class="md-stepper__stepper-list-item">
         <div class="md-stepper__step-title">
-          <div class="md-stepper__step-title-badge-outer-border">
+          <div class="md-stepper__step-title-badge-outer-border [selected]">
             <div class="md-stepper__step-title-badge [completed, selected, disabled]">
               [<MdCheckIcon width="{18}" />, index+1]
               <!-- Icon for checkmark, or the current steps number -->

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -74,8 +74,16 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
       'md-input__wrapper--small': size === 'small',
     });
 
+    const outerWrapperClasses = classnames(
+      'md-input__outer-wrapper',
+      {
+        'md-input__outer-wrapper--small': size === 'small',
+      },
+      outerWrapperClass,
+    );
+
     return (
-      <div className={`md-input__outer-wrapper ${outerWrapperClass}`}>
+      <div className={outerWrapperClasses}>
         <div className="md-input__label">
           {label && label !== '' && <label htmlFor={inputId}>{label}</label>}
           {helpText && helpText !== '' && (

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -18,6 +18,7 @@ export interface MdModalProps {
   className?: string;
   closeOnOutsideClick?: boolean;
   onClose?(_e?: React.MouseEvent): void;
+  size?: string;
 }
 
 const MdModal: React.FunctionComponent<MdModalProps> = ({
@@ -29,6 +30,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
   className = '',
   closeOnOutsideClick = true,
   onClose,
+  size,
 }: MdModalProps) => {
   const classNames = classnames(
     'md-modal',
@@ -39,6 +41,10 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
     className,
   );
   const modalRef = useRef<HTMLDivElement>(null);
+
+  const innerWrapperClassNames = classnames('md-modal__inner-wrapper', {
+    'md-modal__inner-wrapper--small': size === 'small',
+  });
 
   /**
    * Focus trap for keyboard users. Makes it impossible to tab out of modal,
@@ -105,7 +111,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
                 closeModal(e);
               }
             }}
-            className="md-modal__inner-wrapper"
+            className={innerWrapperClassNames}
             ref={modalRef}
           >
             <div className="md-modal__header">

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -117,6 +117,17 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    size: {
+      type: { name: 'string' },
+      description: 'Fixed size small modal, when specifying "small" as value',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
   },
 };
 


### PR DESCRIPTION
# Describe your changes
Some small adjustments to components to make them more responsive when screen size changes:
1. Changed width settings of select, autocomplete and multiselect elements to max-width instead of width, so they can go smaller than that if there's less space. To fix situations like these (MdSelect-component seen here on mobile screen):
![image](https://github.com/miljodir/md-components/assets/108116520/560ae88b-d312-4001-8e23-c47a2438e19a)

2. Added "small"-width to MdInput outer wrapper. Even though I use MdInput with size="small" here, it still takes up all that extra width because the outer wrapper didn't have a width restriction like the inner wrapper does when size is set to small:
![image](https://github.com/miljodir/md-components/assets/108116520/3fdee24f-627a-41d3-82ec-e1a6405cccdd)

3. We needed a modal in our form, that doesn't change size according to it's content because the content changes a lot when used so the modal would "jump around" both horizontally and vertically as the user was typing in it. I added a "small"-setting to MdModal, which have a fixed vh/vw size regardless of its content.

Otherwise our modal would start out small like this, before the user searched for anything:
![image](https://github.com/miljodir/md-components/assets/108116520/fab0ff7c-bf56-4a9f-aa60-36f1e326cb5e)

And then when the search result was present it would expand to this:
![image](https://github.com/miljodir/md-components/assets/108116520/cab18876-550b-45a5-a6c6-d2d6537f7e11)

And if the user kept writing in the search field to the point where the search yielded no results it would shrink again to:
![image](https://github.com/miljodir/md-components/assets/108116520/ba6e832e-335d-4d91-b5ac-229b7addc14d)


## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
