### PR TITLE
MdModal enable className customization

### DIFF
--- a/packages/css/src/modal/modal.css
+++ b/packages/css/src/modal/modal.css
@@ -40,14 +40,6 @@
   box-shadow: 8px 8px 16px var(--mdGreyColor60);
 }
 
-.md-modal__inner-wrapper--small {
-  width: 40vw;
-  height: 40vh;
-
-  display: flex;
-  flex-direction: column;
-}
-
 .md-modal--error .md-modal__inner-wrapper {
   border: 2px solid var(--mdErrorColor);
 }
@@ -82,13 +74,4 @@
 
 .md-modal__content-inner {
   padding-right: 2em;
-  flex-grow: 1;
-}
-
-/* Media */
-@media (max-width: 768px) {
-  .md-modal__inner-wrapper--small {
-    width: 80vw;
-    height: 60vh;
-  }
 }

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -18,7 +18,6 @@ export interface MdModalProps {
   className?: string;
   closeOnOutsideClick?: boolean;
   onClose?(_e?: React.MouseEvent): void;
-  size?: string;
 }
 
 const MdModal: React.FunctionComponent<MdModalProps> = ({
@@ -30,21 +29,14 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
   className = '',
   closeOnOutsideClick = true,
   onClose,
-  size,
 }: MdModalProps) => {
-  const classNames = classnames(
-    'md-modal',
-    {
-      'md-modal--open': !!open,
-      'md-modal--error': !!error,
-    },
-    className,
-  );
+  const classNames = classnames('md-modal', {
+    'md-modal--open': !!open,
+    'md-modal--error': !!error,
+  });
   const modalRef = useRef<HTMLDivElement>(null);
 
-  const innerWrapperClassNames = classnames('md-modal__inner-wrapper', {
-    'md-modal__inner-wrapper--small': size === 'small',
-  });
+  const innerWrapperClassNames = classnames('md-modal__inner-wrapper', className);
 
   /**
    * Focus trap for keyboard users. Makes it impossible to tab out of modal,

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -117,17 +117,6 @@ export default {
       },
       control: { type: 'boolean' },
     },
-    size: {
-      type: { name: 'string' },
-      description: 'Fixed size small modal, when specifying "small" as value',
-      table: {
-        defaultValue: { summary: 'null' },
-        type: {
-          summary: 'string',
-        },
-      },
-      control: { type: 'text' },
-    },
   },
 };
 


### PR DESCRIPTION
# Describe your changes

Reverted size-prop changes from last pr and moved className-prop to inner wrapper instead. That way it's possible to set any custom width/height on the modal from an outside class. Or use it to change the background color, layout style etc. on the modal.

Marked as minor relase instead of patch, since this change removes the possibility to set a custom css class om the outer container, which could possibly be a breaking change if anyone has made use of that functionality. We're assuming this will not cause much trouble though, since its the actual modal-element inside that one would want to change anything on...

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
