### PR TITLE
fix: MdInput, MdTextAre shifting position on focus

### DIFF
--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -27,7 +27,7 @@
 .md-input:not(.md-input.md-input--readonly):not(.md-input.md-input--disabled):active,
 .md-input:not(.md-input.md-input--readonly):not(.md-input.md-input--disabled):focus {
   outline: 2px solid var(--mdPrimaryColor80);
-  outline-offset: -1;
+  outline-offset: -2px;
   border-color: transparent;
 }
 

--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -26,9 +26,9 @@
 
 .md-input:not(.md-input.md-input--readonly):not(.md-input.md-input--disabled):active,
 .md-input:not(.md-input.md-input--readonly):not(.md-input.md-input--disabled):focus {
-  margin: 0;
-  border: 2px solid var(--mdPrimaryColor80);
-  outline: none;
+  outline: 2px solid var(--mdPrimaryColor80);
+  outline-offset: -1;
+  border-color: transparent;
 }
 
 .md-input.md-input--disabled:focus,

--- a/packages/css/src/formElements/textarea/textarea.css
+++ b/packages/css/src/formElements/textarea/textarea.css
@@ -20,7 +20,7 @@
 .md-textarea:not(.md-textarea.md-textarea--readonly):not(.md-textarea.md-textarea--disabled):active,
 .md-textarea:not(.md-textarea.md-textarea--readonly):not(.md-textarea.md-textarea--disabled):focus {
   outline: 2px solid var(--mdPrimaryColor80);
-  outline-offset: -1;
+  outline-offset: -2px;
   border-color: transparent;
 }
 

--- a/packages/css/src/formElements/textarea/textarea.css
+++ b/packages/css/src/formElements/textarea/textarea.css
@@ -19,9 +19,9 @@
 
 .md-textarea:not(.md-textarea.md-textarea--readonly):not(.md-textarea.md-textarea--disabled):active,
 .md-textarea:not(.md-textarea.md-textarea--readonly):not(.md-textarea.md-textarea--disabled):focus {
-  margin: 0;
-  border: 2px solid var(--mdPrimaryColor80);
-  outline: none;
+  outline: 2px solid var(--mdPrimaryColor80);
+  outline-offset: -1;
+  border-color: transparent;
 }
 
 .md-textarea.md-textarea--disabled:focus,

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -205,7 +205,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             <div
               aria-labelledby={label && label !== '' ? `md-autocomplete_label_${autocompleteId}` : undefined}
               role="listbox"
-              id={`md-autocomplete__dropdown_${autocompleteId}`}
+              id={`md-autocomplete_dropdown_${autocompleteId}`}
               className="md-autocomplete__dropdown"
               style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
             >


### PR DESCRIPTION
# Describe your changes

Use outline instead of border to avoid input content or content below it shifting on focus.
Also fix small a11y bug (mismatch of id's).

![Animation](https://github.com/miljodir/md-components/assets/66901228/df826647-3916-4382-87de-20239fc5de2c)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
