### PR TITLE
Add support for string alternative for max and min property on input component

### DIFF
--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -30,8 +30,8 @@ export interface MdInputProps {
   onKeyDown?(_e: React.KeyboardEvent<HTMLInputElement>): void;
   minLength?: number;
   maxLength?: number;
-  min?: number;
-  max?: number;
+  min?: number | string;
+  max?: number | string;
   step?: number;
 }
 

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -258,6 +258,22 @@ export default {
       // eslint-disable-next-line quotes
       description: "Ref to the inner input element, use for example to bring focus to the input when there's an error.",
     },
+    min: {
+      type: { name: 'number | string' },
+      description: 'The minimum value of input value',
+      table: {
+        type: { summary: 'number | string' },
+      },
+      control: { type: 'text' },
+    },
+    max: {
+      type: { name: 'number | string' },
+      description: 'The maximum value of input value',
+      table: {
+        type: { summary: 'number | string' },
+      },
+      control: { type: 'text' },
+    },
   },
 };
 


### PR DESCRIPTION
# Describe your changes

Add support for string alternative for max and min property (previously only number) on input component. 
This will make it possible to set min and max value for input-components with type "date", maybe other types as well, I haven't checked.

Added the min and max property to the input-story to make the properties testable from det storybook

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
