### PR TITLE
Ref on MdTextArea

### DIFF
--- a/packages/react/src/formElements/MdTextArea.tsx
+++ b/packages/react/src/formElements/MdTextArea.tsx
@@ -23,75 +23,81 @@ export interface MdTextAreaProps {
   onFocus?(_e: React.FocusEvent<HTMLTextAreaElement>): void;
 }
 
-const MdTextArea: React.FunctionComponent<MdTextAreaProps> = ({
-  label,
-  id,
-  rows = 10,
-  value = '',
-  placeholder,
-  disabled = false,
-  readOnly = false,
-  error = false,
-  errorText,
-  helpText,
-  outerWrapperClass = '',
-  ...otherProps
-}: MdTextAreaProps) => {
-  const [helpOpen, setHelpOpen] = useState(false);
-  const textAreaId = id && id !== '' ? id : uuidv4();
+const MdTextArea: React.FunctionComponent<MdTextAreaProps> = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
+  (
+    {
+      label,
+      id,
+      rows = 10,
+      value = '',
+      placeholder,
+      disabled = false,
+      readOnly = false,
+      error = false,
+      errorText,
+      helpText,
+      outerWrapperClass = '',
+      ...otherProps
+    },
+    ref,
+  ) => {
+    const [helpOpen, setHelpOpen] = useState(false);
+    const textAreaId = id && id !== '' ? id : uuidv4();
 
-  const classNames = classnames('md-textarea', {
-    'md-textarea--disabled': !!disabled,
-    'md-textarea--readonly': !!readOnly,
-    'md-textarea--error': !!error,
-  });
+    const classNames = classnames('md-textarea', {
+      'md-textarea--disabled': !!disabled,
+      'md-textarea--readonly': !!readOnly,
+      'md-textarea--error': !!error,
+    });
 
-  return (
-    <div className={`md-textarea__outer-wrapper ${outerWrapperClass}`}>
-      <div className="md-textarea__label">
-        {label && label !== '' && <label htmlFor={textAreaId}>{label}</label>}
+    return (
+      <div className={`md-textarea__outer-wrapper ${outerWrapperClass}`}>
+        <div className="md-textarea__label">
+          {label && label !== '' && <label htmlFor={textAreaId}>{label}</label>}
+          {helpText && helpText !== '' && (
+            <div className="md-textarea__help-button">
+              <MdHelpButton
+                ariaLabel={`Hjelpetekst for ${label}`}
+                id={`md-textarea_help-button_${textAreaId}`}
+                aria-expanded={helpOpen}
+                aria-controls={`md-textarea_help-text_${textAreaId}`}
+                onClick={() => {
+                  return setHelpOpen(!helpOpen);
+                }}
+                expanded={helpOpen}
+              />
+            </div>
+          )}
+        </div>
+
         {helpText && helpText !== '' && (
-          <div className="md-textarea__help-button">
-            <MdHelpButton
-              ariaLabel={`Hjelpetekst for ${label}`}
-              id={`md-textarea_help-button_${textAreaId}`}
-              aria-expanded={helpOpen}
-              aria-controls={`md-textarea_help-text_${textAreaId}`}
-              onClick={() => {
-                return setHelpOpen(!helpOpen);
-              }}
-              expanded={helpOpen}
-            />
+          <div className={`md-textarea__help-text ${helpOpen ? 'md-textarea__help-text--open' : ''}`}>
+            <MdHelpText
+              id={`md-textarea_help-text_${textAreaId}`}
+              aria-labelledby={helpText && helpText !== '' ? `md-textarea_help-button_${textAreaId}` : undefined}
+            >
+              {helpText}
+            </MdHelpText>
           </div>
         )}
-      </div>
-
-      {helpText && helpText !== '' && (
-        <div className={`md-textarea__help-text ${helpOpen ? 'md-textarea__help-text--open' : ''}`}>
-          <MdHelpText
-            id={`md-textarea_help-text_${textAreaId}`}
-            aria-labelledby={helpText && helpText !== '' ? `md-textarea_help-button_${textAreaId}` : undefined}
-          >
-            {helpText}
-          </MdHelpText>
+        <div className="md-textarea__wrapper">
+          <textarea
+            id={textAreaId}
+            aria-describedby={helpText && helpText !== '' ? `md-textarea_help-text_${textAreaId}` : undefined}
+            value={value}
+            rows={rows}
+            className={classNames}
+            placeholder={placeholder}
+            disabled={!!disabled}
+            readOnly={!!readOnly}
+            ref={ref}
+            {...otherProps}
+          />
         </div>
-      )}
-      <div className="md-textarea__wrapper">
-        <textarea
-          id={textAreaId}
-          aria-describedby={helpText && helpText !== '' ? `md-textarea_help-text_${textAreaId}` : undefined}
-          value={value}
-          rows={rows}
-          className={classNames}
-          placeholder={placeholder}
-          disabled={!!disabled}
-          readOnly={!!readOnly}
-          {...otherProps}
-        />
+        {error && errorText && errorText !== '' && <div className="md-textarea__error">{errorText}</div>}
       </div>
-      {error && errorText && errorText !== '' && <div className="md-textarea__error">{errorText}</div>}
-    </div>
-  );
-};
-
+    );
+  },
+);
+MdTextArea.displayName = 'MdTextArea';
 export default MdTextArea;

--- a/packages/react/src/formElements/MdTextArea.tsx
+++ b/packages/react/src/formElements/MdTextArea.tsx
@@ -23,7 +23,7 @@ export interface MdTextAreaProps {
   onFocus?(_e: React.FocusEvent<HTMLTextAreaElement>): void;
 }
 
-const MdTextArea: React.FunctionComponent<MdTextAreaProps> = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
+const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
   (
     {
       label,


### PR DESCRIPTION
# Describe your changes

Added a forwardRef to MdTextArea to be able to focus on the inner text area through use of ref's. Specific use case is when there are form validation errors and the text area should be focused.
(Same functionality is in place for MdInput and MdSelect)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
