### PR TITLE
RB-2548: Add max element amount to MdAutocomplete

### DIFF
--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -29,6 +29,7 @@ export interface MdAutocompleteProps {
   errorText?: string;
   prefixIcon?: React.ReactNode;
   dropdownHeight?: number;
+  amountOfElementsShown?: number;
 }
 
 const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
@@ -48,6 +49,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       prefixIcon = null,
       onChange,
       dropdownHeight,
+      amountOfElementsShown = null,
       ...otherProps
     },
     ref,
@@ -107,6 +109,10 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
         'md-autocomplete__dropdown-item--selected': isSelectedOption(option),
       });
     };
+
+    const displayedItems = autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : [];
+    const displayedItemsSliced =
+      amountOfElementsShown == null ? displayedItems : displayedItems.slice(0, amountOfElementsShown);
 
     return (
       <div className={classNames}>
@@ -209,7 +215,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
               className="md-autocomplete__dropdown"
               style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
             >
-              {(autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : []).map(option => {
+              {displayedItemsSliced.map(option => {
                 return (
                   <button
                     role="option"

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -110,9 +110,9 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       });
     };
 
-    const displayedItems = autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : [];
-    const displayedItemsSliced =
-      amountOfElementsShown == null ? displayedItems : displayedItems.slice(0, amountOfElementsShown);
+    const displayedOptions = autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : [];
+    const displayedOptionsSliced =
+      amountOfElementsShown == null ? displayedOptions : displayedOptions.slice(0, amountOfElementsShown);
 
     return (
       <div className={classNames}>
@@ -215,7 +215,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
               className="md-autocomplete__dropdown"
               style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
             >
-              {displayedItemsSliced.map(option => {
+              {displayedOptionsSliced.map(option => {
                 return (
                   <button
                     role="option"

--- a/stories/Autocomplete.stories.tsx
+++ b/stories/Autocomplete.stories.tsx
@@ -156,6 +156,17 @@ export default {
       },
       control: { type: 'number' },
     },
+    amountOfElementsShown: {
+      type: { name: 'number' },
+      description: 'Set max number of elements shown in the dropdown',
+      table: {
+        defaultValue: { summary: 'variable' },
+        type: {
+          summary: 'number',
+        },
+      },
+      control: { type: 'number' },
+    },
     inputRef: {
       type: { name: 'Ref<HTMLButtonElement>' },
       description:


### PR DESCRIPTION
# Describe your changes

Adds the variable `amountOfElementsShown` to the `MdAutocomplete` component. It makes it possible to set a maximum amount of elements shown in the dropdown, which is useful when you have a very long list of options.

It has a default value of `null`, that returns the whole list. So it does not change existing instances of this component.

## Checklist before requesting a review

- [X] I have performed a self-review and test of my code
- [X] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
