### PR TITLE
RB-2548: Only generate input id once

### DIFF
--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -55,11 +55,10 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [open, setOpen] = useState(false);
     const [helpOpen, setHelpOpen] = useState(false);
     const [autocompleteValue, setAutocompleteValue] = useState('');
+    const [autocompleteId] = useState(id && id !== '' ? id : uuidv4());
     const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
-
-    const autocompleteId = id && id !== '' ? id : uuidv4();
 
     const classNames = classnames('md-autocomplete', {
       'md-autocomplete--open': !!open,


### PR DESCRIPTION
# Describe your changes

Changes `autocompleteId `to use state so that the id is not re-generated on each render. 

This code change was done because utilizing the `ref `in a parent to retrieve the id became unnecessarily complex when the input's id rapidly changed. It is also generally not a good idea to have html elements' ids change on every render since they are made to identify the element.

## Checklist before requesting a review

- [X] I have performed a self-review and test of my code
- [X] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
