### PR TITLE
Fix for focus trap not attached

### DIFF
--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -44,6 +44,8 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
    * Also focuses on the first focusable element when modal is opened.
    */
   useEffect(() => {
+    if (!open) return;
+
     const keyListener = (event: KeyboardEvent) => {
       if (event.key === 'Tab') {
         const focusableElements = modalRef.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);
@@ -80,7 +82,7 @@ const MdModal: React.FunctionComponent<MdModalProps> = ({
     return () => {
       return document.removeEventListener('keydown', keyListener);
     };
-  }, []);
+  }, [open]);
 
   const closeModal = (e: React.MouseEvent) => {
     if (onClose) {


### PR DESCRIPTION
# Describe your changes

Experienced the MdModal-component not having focus trap enabled. This fix makes sure the useEffect that registers the eventhandler for focus trapping is run after modal is opened.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
