### PR TITLE
MdAlertMessage with ReactNode contents

### DIFF
--- a/packages/css/src/messages/AlertMessage.md
+++ b/packages/css/src/messages/AlertMessage.md
@@ -10,8 +10,13 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
 <div
   className="md-alert-message [md-alert-message--confirm, md-alert-message--warning, md-alert-message--error, md-alert-message--fullWidth]"
 >
-  <div className="md-alert-message__content">{Icon width="20" height="20"} {label}</div>
+  <div className="md-alert-message__content">
+    <Icon className="md-alert-message__icon" width="20" height="20" />
+    {label}
+  </div>
 
-  <button className="md-alert-message__button" onClick="{handleClick}">{Icon width="16" height="16"}</button>
+  <button className="md-alert-message__button" onClick="{handleClick}">
+    <Icon width="16" height="16" />
+  </button>
 </div>
 ```

--- a/packages/css/src/messages/alertMessage.css
+++ b/packages/css/src/messages/alertMessage.css
@@ -2,10 +2,10 @@
 .md-info-box {
   display: flex;
   align-items: center;
-  gap: 1em;
+  gap: 1rem;
   font-family: 'Open sans';
-  font-size: 1em;
-  padding: 1em;
+  font-size: 1rem;
+  padding: 1rem;
   background-color: var(--mdSecondaryColor20);
   border: 1px dashed var(--mdPrimaryColor);
 }
@@ -19,7 +19,7 @@
   align-items: center;
   justify-content: space-between;
   font-family: 'Open sans';
-  font-size: 1em;
+  font-size: 1rem;
   width: 100%;
   background-color: var(--mdPrimaryColor10);
 }
@@ -39,18 +39,29 @@
   color: #fff;
 }
 
+.md-alert-message__icon {
+  flex-shrink: 0;
+}
+
 .md-alert-message__content {
   display: flex;
   align-items: center;
-  gap: 1em;
-  padding: 1em;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.md-alert-message__content--start {
+  align-items: flex-start;
+}
+.md-alert-message__content--end {
+  align-items: flex-end;
 }
 
 .md-alert-message__button {
   border: 0;
   background-color: transparent;
   margin: 0;
-  padding: 1em;
+  padding: 1rem;
   cursor: pointer;
 }
 

--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -8,13 +8,14 @@ import MdXIcon from '../icons/MdXIcon';
 
 export interface MdAlertMessageProps {
   theme?: 'info' | 'confirm' | 'warning' | 'error';
-  label?: string;
+  label?: string | React.ReactNode;
   hideIcon?: boolean;
   closable?: boolean;
   fullWidth?: boolean;
   onClose?(_e: React.MouseEvent): void;
   customIcon?: React.ReactNode | string;
   className?: string;
+  alignContent?: 'start' | 'center' | 'end';
 }
 
 const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
@@ -26,6 +27,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   onClose,
   customIcon,
   className,
+  alignContent,
 }: MdAlertMessageProps) => {
   const classNames = classnames(
     'md-alert-message',
@@ -38,14 +40,21 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
     className,
   );
 
+  const contentClassNames = classnames('md-alert-message__content', {
+    'md-alert-message__content--start': alignContent === 'start',
+    'md-alert-message__content--end': alignContent === 'end',
+  });
+
   const renderIcon = () => {
-    let icon = (<MdInfoIcon aria-label="Info" width="20" height="20" />) as React.ReactNode;
+    let icon = (
+      <MdInfoIcon className="md-alert-message__icon" aria-label="Info" width="20" height="20" />
+    ) as React.ReactNode;
     if (customIcon) {
       icon = customIcon;
     } else if (theme === 'confirm') {
-      icon = <MdCheckIcon aria-label="Bekreft" width="20" height="20" />;
+      icon = <MdCheckIcon className="md-alert-message__icon" aria-label="Bekreft" width="20" height="20" />;
     } else if (theme === 'warning' || theme === 'error') {
-      icon = <MdWarningIcon aria-label="Advarsel" width="20" height="20" />;
+      icon = <MdWarningIcon className="md-alert-message__icon" aria-label="Advarsel" width="20" height="20" />;
     }
     return icon;
   };
@@ -58,7 +67,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
 
   return (
     <div className={classNames}>
-      <div className="md-alert-message__content">
+      <div className={contentClassNames}>
         {!hideIcon && renderIcon()}
         {label}
       </div>

--- a/stories/Messages/AlertMessage.stories.tsx
+++ b/stories/Messages/AlertMessage.stories.tsx
@@ -31,10 +31,11 @@ export default {
   argTypes: {
     label: {
       type: { name: 'string', required: true },
-      description: 'The text to display on hover',
+      description:
+        'The content to display in the alert message. Can be either a plain string or a html-node containing subcontents.',
       table: {
         type: {
-          summary: 'text',
+          summary: 'text | ReactNode',
         },
       },
       control: 'text',
@@ -107,6 +108,17 @@ export default {
         },
       },
       control: { type: 'text' },
+    },
+    alignContent: {
+      description: 'Decides vertical alignement of content i.e. icon and label.',
+      table: {
+        type: {
+          defaultValue: { summary: 'center' },
+          summary: 'text',
+        },
+      },
+      options: ['start', 'center', 'end'],
+      control: { type: 'inline-radio' },
     },
   },
 };


### PR DESCRIPTION
# Describe your changes

Some enhancements to MdAlertMessage-component:

1. Fix so that icon is not shrinked when label wraps across lines:
![image](https://github.com/miljodir/md-components/assets/108116520/5715e849-9d4b-4408-aa14-6ea14f23267c)

2. New prop to control alignment between icon and content/label. Default is still centered, but gives the possibility to set either start or end:
![image](https://github.com/miljodir/md-components/assets/108116520/41528fca-18fa-42e7-8756-fedb99aa8046)

3. Added type ReactNode to label-prop, to allow contents of AlertMessage to be more advanced than a plain string. For example for text split up by controlled new lines. Or to be able to add a heading, bulleted list etc.
![image](https://github.com/miljodir/md-components/assets/108116520/9ed631d5-1c85-4af3-8a76-73557bb877bb)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
