### PR TITLE
Add role prop on alert message and info box

### DIFF
--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -16,6 +16,7 @@ export interface MdAlertMessageProps {
   customIcon?: React.ReactNode | string;
   className?: string;
   alignContent?: 'start' | 'center' | 'end';
+  role?: React.AriaRole;
 }
 
 const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
@@ -28,6 +29,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   customIcon,
   className,
   alignContent,
+  role,
 }: MdAlertMessageProps) => {
   const classNames = classnames(
     'md-alert-message',
@@ -66,7 +68,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   };
 
   return (
-    <div className={classNames}>
+    <div className={classNames} role={role}>
       <div className={contentClassNames}>
         {!hideIcon && renderIcon()}
         {label}

--- a/packages/react/src/messages/MdInfoBox.tsx
+++ b/packages/react/src/messages/MdInfoBox.tsx
@@ -7,6 +7,7 @@ export interface MdInfoBoxProps {
   hideIcon?: boolean;
   fullWidth?: boolean;
   customIcon?: React.ReactNode | string;
+  role?: React.AriaRole;
 }
 
 const MdInfoBox: React.FC<MdInfoBoxProps> = ({
@@ -14,6 +15,7 @@ const MdInfoBox: React.FC<MdInfoBoxProps> = ({
   hideIcon = false,
   fullWidth = false,
   customIcon,
+  role,
 }: MdInfoBoxProps) => {
   const classNames = classnames('md-info-box', {
     'md-info-box--fullWidth': !!fullWidth,
@@ -28,7 +30,7 @@ const MdInfoBox: React.FC<MdInfoBoxProps> = ({
   };
 
   return (
-    <div className={classNames}>
+    <div className={classNames} role={role}>
       {!hideIcon && renderIcon()}
       {label}
     </div>


### PR DESCRIPTION
# Describe your changes

Added optional property "role" on MdAlertMessage and MdInfoBox. To be able to specify correct role from outside, based on use case. Role "status", "alert" and "alertdialog" are all possibly correct roles, depending on how the components are used in context of the application.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
