### PR TITLE
Revert autocomplete close on input click (#120) and fix placeholder interaction

### DIFF
--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -60,6 +60,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [results, setResults] = useState<MdAutocompleteOptionProps[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
+    const [displayValue, setDisplayValue] = useState('');
 
     const autocompleteId = id && id !== '' ? id : uuidv4();
 
@@ -78,26 +79,22 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       'md-autocomplete--small': size === 'small',
     });
 
-    const selectedOption =
-      value && value !== ''
-        ? options &&
-          options.find(o => {
-            return o.value === value;
-          })
-        : '';
-
-    let displayValue = placeholder;
-    if (selectedOption && selectedOption.value) {
-      displayValue = selectedOption.text;
-    }
-    if (open) {
-      displayValue = '';
-    }
-
     const handleOptionClick = (option: MdAutocompleteOptionProps) => {
       onChange(option);
       setOpen(false);
       setAutocompleteValue('');
+
+      const selectedOption =
+        value && value !== ''
+          ? options &&
+            options.find(o => {
+              return o.value === value;
+            })
+          : '';
+
+      if (selectedOption && selectedOption.value) {
+        setDisplayValue(selectedOption.text);
+      }
     };
 
     const isSelectedOption = (option: MdAutocompleteOptionProps) => {
@@ -110,7 +107,13 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       });
     };
 
-    const displayedOptions = autocompleteValue ? results : defaultOptions ? defaultOptions : options ? options : [];
+    const displayedOptions = autocompleteValue
+      ? results
+      : defaultOptions && defaultOptions.length
+      ? defaultOptions
+      : options
+      ? options
+      : [];
     const displayedOptionsSliced =
       amountOfElementsShown == null ? displayedOptions : displayedOptions.slice(0, amountOfElementsShown);
 
@@ -178,9 +181,6 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             className={inputClassNames}
             value={open ? autocompleteValue : displayValue}
             tabIndex={0}
-            onClick={() => {
-              return !disabled && setOpen(!open);
-            }}
             onKeyDown={e => {
               if (e.key === 'Enter') {
                 setOpen(!open);


### PR DESCRIPTION
# Describe your changes

Opplevde problemer med forrige commits feaure. Fant en annen feil i prosessen:
Placeholder-logikken er kopiert fra select der det ikke finnes "placeholder" fordi det brukes buttons. Derfor kunne vi endre placeholder-logikk i denne komponenten.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
