### PR TITLE
fix: MdTooltip missing controls in Storybook

### DIFF
--- a/packages/css/src/button/README.md
+++ b/packages/css/src/button/README.md
@@ -7,7 +7,7 @@ Class names and elements in brackets [] are optional-/togglable-/decorator- or s
 See [Storybook](https://miljodir.github.io/md-components) for examples and more info.
 
 ```html
-<button className="md-button [md-button--small, md-button--secondary, md-button--danger, md-button--column]">
+<button className="md-button [md-button--small, md-button--secondary, md-button--tertiary, md-button--danger, md-button--column]">
   [
   <div className="md-button__topIcon">{topIcon}</div>
   ] [

--- a/packages/css/src/tooltip/tooltip.css
+++ b/packages/css/src/tooltip/tooltip.css
@@ -37,6 +37,7 @@
 .md-tooltip__child {
   display: flex;
   cursor: pointer;
+  width: fit-content;
 }
 
 

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -31,14 +31,23 @@ export default {
     },
   },
   argTypes: {
-    label: {
-      description: 'The text to display on hover',
+    content: {
+      description: 'The content to display on hover',
       table: {
         type: {
-          summary: 'text',
+          summary: 'ReactNode',
         },
       },
-      control: 'text',
+      control: { type: 'text' },
+    },
+    ariaLabel: {
+      description: 'The aria label for the tooltip',
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
     },
     position: {
       description: 'Selected position for the tooltip',


### PR DESCRIPTION
# Describe your changes

The Storybook docs for MdTooltip did not have updated controls. Added missing controls, fixed minor CSS issue and added tertiary theme to MdButton README example docs.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
