### PR TITLE
fix: Incorrect button padding when using left/right-icon

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -42,8 +42,8 @@
 
 .md-button__rightIcon {
   height: 1rem;
-  flex-shrink: 0;
   width: 1rem;
+  flex-shrink: 0;
   margin-left: 0.4rem;
 }
 

--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -36,19 +36,13 @@
 .md-button__leftIcon {
   height: 1rem;
   width: 1rem;
-  position: relative;
-  right: 0.5rem;
-  top: 0;
-  flex-shrink: 0;
+  margin-right: 0.4rem;
 }
 
 .md-button__rightIcon {
   height: 1rem;
   width: 1rem;
-  position: relative;
-  left: 0.5rem;
-  top: 0;
-  flex-shrink: 0;
+  margin-left: 0.4rem;
 }
 
 .md-button:focus {

--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -36,11 +36,13 @@
 .md-button__leftIcon {
   height: 1rem;
   width: 1rem;
+  flex-shrink: 0;
   margin-right: 0.4rem;
 }
 
 .md-button__rightIcon {
   height: 1rem;
+  flex-shrink: 0;
   width: 1rem;
   margin-left: 0.4rem;
 }


### PR DESCRIPTION
# Describe your changes

Padding on buttons when using left/right-icon was incorrect. Fixed. This was especially apparent when using a small button with an icon.

![image](https://github.com/miljodir/md-components/assets/66901228/0011c196-f5fb-4881-9fac-c2f6ac6a8db5)
![image](https://github.com/miljodir/md-components/assets/66901228/f2613514-9d2d-46f7-8b68-85aac7ef4cb6)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
