### PR TITLE
More advanced input suffix

### DIFF
--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -20,7 +20,7 @@ export interface MdInputProps {
   hideErrorIcon?: boolean;
   helpText?: string;
   outerWrapperClass?: string;
-  suffix?: React.ReactNode;
+  suffix?: string | React.ReactNode;
   prefixIcon?: React.ReactNode;
   hideNumberArrows?: boolean;
   onChange?(_e: React.ChangeEvent<HTMLInputElement>): void;

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -20,7 +20,7 @@ export interface MdInputProps {
   hideErrorIcon?: boolean;
   helpText?: string;
   outerWrapperClass?: string;
-  suffix?: string;
+  suffix?: React.ReactNode;
   prefixIcon?: React.ReactNode;
   hideNumberArrows?: boolean;
   onChange?(_e: React.ChangeEvent<HTMLInputElement>): void;

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Readme from '../packages/css/src/formElements/input/README.md';
 import MdInput from '../packages/react/src/formElements/MdInput';
 import MdUserIcon from '../packages/react/src/icons/MdUserIcon';
+
 import type { Args } from '@storybook/react';
 import type { ChangeEvent } from 'react';
 
@@ -172,12 +173,12 @@ export default {
       control: { type: 'text' },
     },
     suffix: {
-      type: { name: 'string' },
+      type: { name: 'ReactNode' },
       description: 'Suffix to apply to end of input field',
       table: {
         defaultValue: { summary: 'null' },
         type: {
-          summary: 'string',
+          summary: 'string | DomElement | image | ReactNode',
         },
       },
       control: { type: 'text' },
@@ -322,6 +323,26 @@ InputWithPrefix.args = {
   placeholder: 'Placeholder...',
   id: '',
   suffix: '',
+  prefixIcon: <MdUserIcon />,
+  hideNumberArrows: false,
+};
+
+export const InputWithSuffix = Template.bind({});
+InputWithSuffix.args = {
+  value: '',
+  label: 'Label',
+  type: 'text',
+  size: 'normal',
+  disabled: false,
+  readOnly: false,
+  error: false,
+  errorText: '',
+  hideErrorIcon: false,
+  helpText: '',
+  outerWrapperClass: '',
+  placeholder: 'Placeholder...',
+  id: '',
+  suffix: <button>Clear</button>,
   prefixIcon: <MdUserIcon />,
   hideNumberArrows: false,
 };

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -173,7 +173,7 @@ export default {
       control: { type: 'text' },
     },
     suffix: {
-      type: { name: 'ReactNode' },
+      type: { name: 'string' },
       description: 'Suffix to apply to end of input field',
       table: {
         defaultValue: { summary: 'null' },


### PR DESCRIPTION
# Describe your changes

Expanded the type of the suffix-prop on MdInput, to be able to add an icon, or button there instead of just text. Specific use case that triggered the need for change is having an icon button for clearing the input:
![image](https://github.com/miljodir/md-components/assets/108116520/f956a6d9-6788-4c0e-9441-9f31108646ed)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
