### PR TITLE
Extend Md components' props with appropriate standard HTML attributes

### DIFF
--- a/packages/css/src/formElements/radiobutton/README.md
+++ b/packages/css/src/formElements/radiobutton/README.md
@@ -7,18 +7,18 @@ Class names in brackets [] are optional-/togglable-/decorator- or state dependan
 See [Storybook](https://miljodir.github.io/md-components) for examples and more info.
 
 ```html
-    <div className="md-radiobutton [md-checkbox--disabled]">
-      <span className="md-radiobutton__check-area">
-        <span className="md-radiobutton__selected-dot" />
-      </span>
-      <input
-        id={String(radioGroupId) || undefined}
-        type="radio"
-        value={value}
-        checked="{true|false}"
-        disabled="{disabled}"
-        {...otherProps}
-      />
-      <label>{label}</label>
-    </div>
+<div className="md-radiobutton [md-checkbox--disabled]">
+  <span className="md-radiobutton__check-area">
+    <span className="md-radiobutton__selected-dot" />
+  </span>
+  <input
+    id="{radioGroupId}"
+    type="radio"
+    value="{value}"
+    checked="{true|false}"
+    disabled="{disabled}"
+    {...otherProps}
+  />
+  <label>{label}</label>
+</div>
 ```

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -7,7 +7,7 @@ import MdMinusIcon from '../icons/MdMinusIcon';
 export interface MdAccordionItemProps {
   label?: string;
   headerContent?: React.ReactNode | string;
-  id?: string | number | null | undefined;
+  id?: string | null | undefined;
   expanded?: boolean;
   theme?: string;
   disabled?: boolean;
@@ -74,7 +74,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
     <div className={accordionClassNames}>
       {/* Header */}
       <button
-        id={String(accordionId) || undefined}
+        id={accordionId}
         type="button"
         aria-expanded={isExpanded}
         aria-controls={`md-accordion-item_content_${accordionId}`}
@@ -95,7 +95,7 @@ const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
       {!disabled && (
         <div
           id={`md-accordion-item_content_${accordionId}`}
-          aria-labelledby={String(accordionId) || undefined}
+          aria-labelledby={accordionId}
           className={contentClassNames}
         >
           <div className="md-accordion-item__content-inner">{children}</div>

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -7,7 +7,7 @@ import MdMinusIcon from '../icons/MdMinusIcon';
 export interface MdAccordionItemProps {
   label?: string;
   headerContent?: React.ReactNode | string;
-  id?: string | null | undefined;
+  id?: string;
   expanded?: boolean;
   theme?: string;
   disabled?: boolean;
@@ -22,7 +22,7 @@ export interface MdAccordionItemProps {
 const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
   label = '',
   headerContent,
-  id = null,
+  id,
   expanded = false,
   theme,
   disabled = false,

--- a/packages/react/src/chips/MdFilterChip.tsx
+++ b/packages/react/src/chips/MdFilterChip.tsx
@@ -4,13 +4,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 import MdCheckIcon from '../icons/MdCheckIcon';
 
-export interface MdFilterChipProps {
+export interface MdFilterChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string | null;
-  id?: string | number;
   active?: boolean;
-  disabled?: boolean;
   prefixIcon?: React.ReactNode;
-  onClick?(_e: React.MouseEvent<HTMLButtonElement>): void;
   className?: string;
 }
 
@@ -34,7 +31,7 @@ const MdFilterChip: React.FunctionComponent<MdFilterChipProps> = ({
       type="button"
       aria-pressed={active}
       className={buttonClassNames}
-      id={String(chipId) || undefined}
+      id={chipId || undefined}
       disabled={disabled}
       {...otherProps}
     >

--- a/packages/react/src/chips/MdInputChip.tsx
+++ b/packages/react/src/chips/MdInputChip.tsx
@@ -4,14 +4,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 import MdXIcon from '../icons/MdXIcon';
 
-export interface MdInputChipProps {
+export interface MdInputChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string | null;
-  id?: string | number;
   active?: boolean;
-  disabled?: boolean;
   prefixIcon?: React.ReactNode;
-  onClick?(_e: React.MouseEvent<HTMLButtonElement>): void;
-  className?: string;
   hideCloseIcon?: boolean;
   solid?: boolean;
 }
@@ -35,13 +31,7 @@ const MdInputChip: React.FunctionComponent<MdInputChipProps> = ({
   });
 
   return (
-    <button
-      type="button"
-      className={buttonClassNames}
-      id={String(chipId) || undefined}
-      disabled={disabled}
-      {...otherProps}
-    >
+    <button type="button" className={buttonClassNames} id={chipId || undefined} disabled={disabled} {...otherProps}>
       {prefixIcon && (
         <div aria-hidden="true" className="md-chip__left-icon">
           {prefixIcon}

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -133,7 +133,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
             {helpText && helpText !== '' && (
               <div className="md-autocomplete__help-button">
                 <MdHelpButton
-                  ariaLabel={`Hjelpetekst for ${label}`}
+                  aria-label={`Hjelpetekst for ${label}`}
                   id={`md-autocomplete_help-button_${autocompleteId}`}
                   aria-expanded={helpOpen}
                   aria-controls={`md-autocomplete_help-text_${autocompleteId}`}

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -23,10 +23,10 @@ export interface MdAutocompleteProps extends React.InputHTMLAttributes<HTMLInput
    */
   onSelectOption(_e: MdAutocompleteOptionProps): void;
   /**
-   * Replaces previous 'size'-prop for reducing overall size of whole component from full width to either medium or small.
+   * Replaces previous 'size'-prop for reducing overall width of component from large to either medium or small.
    * Size-prop is now reserved as a standard prop on the inner html input element to specify its width.
    */
-  mode: 'full' | 'medium' | 'small';
+  mode: 'large' | 'medium' | 'small';
   helpText?: string;
   error?: boolean;
   errorText?: string;
@@ -45,7 +45,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       id,
       placeholder = 'Søk',
       disabled = false,
-      mode,
+      mode = 'large',
       helpText,
       error = false,
       errorText,

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -13,17 +13,20 @@ export interface MdAutocompleteOptionProps {
   value: string;
 }
 
-export interface MdAutocompleteProps {
+export interface MdAutocompleteProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string | null;
   options: MdAutocompleteOptionProps[];
   defaultOptions?: MdAutocompleteOptionProps[];
-  id?: string;
-  onChange(_e: MdAutocompleteOptionProps): void;
-  name?: string;
-  value?: string | number;
-  placeholder?: string;
-  disabled?: boolean;
-  size?: string;
+  /**
+   * Replaces previous 'onChange'-prop for listening to changes in selected option.
+   * onChange-prop is now reserved as a standard prop om the inner html input element.
+   */
+  onSelectOption(_e: MdAutocompleteOptionProps): void;
+  /**
+   * Replaces previous 'size'-prop for reducing overall size of whole component from full width to either medium or small.
+   * Size-prop is now reserved as a standard prop on the inner html input element to specify its width.
+   */
+  mode: 'full' | 'medium' | 'small';
   helpText?: string;
   error?: boolean;
   errorText?: string;
@@ -42,12 +45,12 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       id,
       placeholder = 'Søk',
       disabled = false,
-      size,
+      mode,
       helpText,
       error = false,
       errorText,
       prefixIcon = null,
-      onChange,
+      onSelectOption,
       dropdownHeight,
       amountOfElementsShown = null,
       ...otherProps
@@ -67,15 +70,15 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       'md-autocomplete--open': !!open,
       'md-autocomplete--error': !!error,
       'md-autocomplete--disabled': !!disabled,
-      'md-autocomplete--medium': size === 'medium',
-      'md-autocomplete--small': size === 'small',
+      'md-autocomplete--medium': mode === 'medium',
+      'md-autocomplete--small': mode === 'small',
     });
 
     const inputClassNames = classnames('md-autocomplete__input', {
       'md-autocomplete__input--open': !!open,
       'md-autocomplete__input--error': !!error,
       'md-autocomplete__input--has-prefix': prefixIcon !== null && prefixIcon !== '',
-      'md-autocomplete--small': size === 'small',
+      'md-autocomplete--small': mode === 'small',
     });
 
     const selectedOption =
@@ -95,7 +98,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     }
 
     const handleOptionClick = (option: MdAutocompleteOptionProps) => {
-      onChange(option);
+      onSelectOption(option);
       setOpen(false);
       setAutocompleteValue('');
     };
@@ -162,7 +165,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
           onClickOutside={() => {
             return setOpen(false);
           }}
-          className={`md-autocomplete__container ${size === 'small' ? 'md-autocomplete--small' : ''}`}
+          className={`md-autocomplete__container ${mode === 'small' ? 'md-autocomplete--small' : ''}`}
         >
           {prefixIcon && (
             <div

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -26,7 +26,7 @@ export interface MdAutocompleteProps extends React.InputHTMLAttributes<HTMLInput
    * Replaces previous 'size'-prop for reducing overall width of component from large to either medium or small.
    * Size-prop is now reserved as a standard prop on the inner html input element to specify its width.
    */
-  mode: 'large' | 'medium' | 'small';
+  mode?: 'large' | 'medium' | 'small';
   helpText?: string;
   error?: boolean;
   errorText?: string;

--- a/packages/react/src/formElements/MdCheckbox.tsx
+++ b/packages/react/src/formElements/MdCheckbox.tsx
@@ -3,23 +3,12 @@ import classnames from 'classnames';
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-export interface MdCheckboxProps {
-  checked?: boolean | undefined;
+export interface MdCheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: any;
-  value?: any;
-  id?: string | number;
-  disabled?: boolean;
-  className?: string;
-  onChange?(_e: React.ChangeEvent<HTMLInputElement>): void;
-  onBlur?(_e: React.FocusEvent<HTMLInputElement>): void;
-  onFocus?(_e: React.FocusEvent<HTMLInputElement>): void;
-  [otherProps: string]: unknown;
 }
 
 const MdCheckbox: React.FunctionComponent<MdCheckboxProps> = ({
-  checked = false,
   label,
-  value,
   id,
   disabled,
   className = '',
@@ -35,16 +24,8 @@ const MdCheckbox: React.FunctionComponent<MdCheckboxProps> = ({
   const checkboxId = id || uuidv4();
   return (
     <div className={classNames}>
-      <input
-        id={String(id || checkboxId) || undefined}
-        className="md-checkbox__input"
-        checked={checked}
-        type="checkbox"
-        value={value}
-        disabled={disabled}
-        {...otherProps}
-      />
-      <label className="md-checkbox__label" htmlFor={String(checkboxId) || undefined}>
+      <input id={id || checkboxId || undefined} className="md-checkbox__input" type="checkbox" {...otherProps} />
+      <label className="md-checkbox__label" htmlFor={checkboxId || undefined}>
         {label && label !== '' && <span className="md-checkbox__labelText">{label}</span>}
       </label>
     </div>

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -15,7 +15,7 @@ export interface MdCheckboxGroupProps {
   options?: MdCheckboxGroupOptionProps[];
   selectedOptions?: MdCheckboxGroupOptionProps[];
   label?: string;
-  id?: string | number;
+  id?: string;
   disabled?: boolean;
   direction?: 'horizontal' | 'vertical' | 'grid';
   columns?: number;
@@ -120,7 +120,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
       )}
 
       <div
-        id={String(checkboxGroupId) || undefined}
+        id={checkboxGroupId}
         aria-describedby={helpText && helpText !== '' ? `md-checkboxgroup_help-text_${checkboxGroupId}` : undefined}
         className={optionsClassNames}
         style={{ gridTemplateColumns: `repeat(${columns}, minmax(max-content, 1fr))` }}

--- a/packages/react/src/formElements/MdCheckboxGroup.tsx
+++ b/packages/react/src/formElements/MdCheckboxGroup.tsx
@@ -94,7 +94,7 @@ const MdCheckboxGroup: React.FunctionComponent<MdCheckboxGroupProps> = ({
         {label && label !== '' && <div>{label}</div>}
         {helpText && helpText !== '' && (
           <MdHelpButton
-            ariaLabel={`Hjelpetekst for ${label}`}
+            aria-label={`Hjelpetekst for ${label}`}
             id={`md-checkboxgroup_help-button_${checkboxGroupId}`}
             aria-expanded={helpOpen}
             aria-controls={`md-checkboxgroup_help-text_${checkboxGroupId}`}

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -16,7 +16,11 @@ export interface MdInputProps extends React.InputHTMLAttributes<HTMLInputElement
   suffix?: string | React.ReactNode;
   prefixIcon?: React.ReactNode;
   hideNumberArrows?: boolean;
-  componentSize?: 'normal' | 'small';
+  /**
+   * Replaces previous 'size'-prop for selecting overall size of whole component as normal or small.
+   * Size-prop is now reserved as a standard prop on the inner html input element to specify its width.
+   */
+  mode?: 'normal' | 'small';
 }
 
 const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
@@ -34,7 +38,7 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
       hideNumberArrows = false,
       disabled = false,
       readOnly = false,
-      componentSize = 'normal',
+      mode = 'normal',
       ...otherProps
     },
     ref,
@@ -43,7 +47,7 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
     const inputId = id && id !== '' ? id : uuidv4();
 
     const classNames = classnames('md-input', {
-      'md-input--small': componentSize === 'small',
+      'md-input--small': mode === 'small',
       'md-input--disabled': !!disabled,
       'md-input--readonly': !!readOnly,
       'md-input--error': !!error,
@@ -53,13 +57,13 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
     });
 
     const wrapperClassNames = classnames('md-input__wrapper', {
-      'md-input__wrapper--small': componentSize === 'small',
+      'md-input__wrapper--small': mode === 'small',
     });
 
     const outerWrapperClasses = classnames(
       'md-input__outer-wrapper',
       {
-        'md-input__outer-wrapper--small': componentSize === 'small',
+        'md-input__outer-wrapper--small': mode === 'small',
       },
       outerWrapperClass,
     );

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -17,7 +17,7 @@ export interface MdInputProps extends React.InputHTMLAttributes<HTMLInputElement
   prefixIcon?: React.ReactNode;
   hideNumberArrows?: boolean;
   /**
-   * Replaces previous 'size'-prop for selecting overall size of whole component as normal or small.
+   * Replaces previous 'size'-prop for selecting overall width of whole component as normal or small.
    * Size-prop is now reserved as a standard prop on the inner html input element to specify its width.
    */
   mode?: 'normal' | 'small';

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -75,7 +75,7 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
           {helpText && helpText !== '' && (
             <div className="md-input__help-button">
               <MdHelpButton
-                ariaLabel={`Hjelpetekst for ${label}`}
+                aria-label={`Hjelpetekst for ${label}`}
                 id={`md-input_help-button_${inputId}`}
                 aria-expanded={helpOpen}
                 aria-controls={`md-input_help-text_${inputId}`}

--- a/packages/react/src/formElements/MdInput.tsx
+++ b/packages/react/src/formElements/MdInput.tsx
@@ -6,15 +6,8 @@ import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 import MdWarningIcon from '../icons/MdWarningIcon';
 
-export interface MdInputProps {
-  value?: string | number | undefined;
-  id?: string;
-  size?: 'normal' | 'small';
+export interface MdInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  type?: string;
-  placeholder?: string;
-  disabled?: boolean;
-  readOnly?: boolean;
   error?: boolean;
   errorText?: string;
   hideErrorIcon?: boolean;
@@ -23,16 +16,7 @@ export interface MdInputProps {
   suffix?: string | React.ReactNode;
   prefixIcon?: React.ReactNode;
   hideNumberArrows?: boolean;
-  onChange?(_e: React.ChangeEvent<HTMLInputElement>): void;
-  onClick?(_e: React.MouseEvent<HTMLInputElement>): void;
-  onBlur?(_e: React.FocusEvent<HTMLInputElement>): void;
-  onFocus?(_e: React.FocusEvent<HTMLInputElement>): void;
-  onKeyDown?(_e: React.KeyboardEvent<HTMLInputElement>): void;
-  minLength?: number;
-  maxLength?: number;
-  min?: number | string;
-  max?: number | string;
-  step?: number;
+  componentSize?: 'normal' | 'small';
 }
 
 const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
@@ -40,12 +24,6 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
     {
       label,
       id,
-      value = '',
-      type = 'text',
-      size = 'normal',
-      placeholder,
-      disabled = false,
-      readOnly = false,
       error = false,
       errorText,
       hideErrorIcon = false,
@@ -54,6 +32,9 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
       suffix = undefined,
       prefixIcon = null,
       hideNumberArrows = false,
+      disabled = false,
+      readOnly = false,
+      componentSize = 'normal',
       ...otherProps
     },
     ref,
@@ -62,7 +43,7 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
     const inputId = id && id !== '' ? id : uuidv4();
 
     const classNames = classnames('md-input', {
-      'md-input--small': size === 'small',
+      'md-input--small': componentSize === 'small',
       'md-input--disabled': !!disabled,
       'md-input--readonly': !!readOnly,
       'md-input--error': !!error,
@@ -72,13 +53,13 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
     });
 
     const wrapperClassNames = classnames('md-input__wrapper', {
-      'md-input__wrapper--small': size === 'small',
+      'md-input__wrapper--small': componentSize === 'small',
     });
 
     const outerWrapperClasses = classnames(
       'md-input__outer-wrapper',
       {
-        'md-input__outer-wrapper--small': size === 'small',
+        'md-input__outer-wrapper--small': componentSize === 'small',
       },
       outerWrapperClass,
     );
@@ -128,12 +109,9 @@ const MdInput = React.forwardRef<HTMLInputElement, MdInputProps>(
             id={inputId}
             aria-describedby={helpText && helpText !== '' ? `md-input_help-text_${inputId}` : undefined}
             className={classNames}
-            value={value}
-            type={type}
-            placeholder={placeholder}
+            ref={ref}
             disabled={!!disabled}
             readOnly={!!readOnly}
-            ref={ref}
             {...otherProps}
           />
 

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -229,7 +229,7 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
                       disabled={!!disabled}
                       data-value={option.value}
                       data-text={option.text}
-                      onKeyDown={(e: React.ChangeEvent & React.KeyboardEvent) => {
+                      onKeyDown={(e: React.ChangeEvent<HTMLInputElement> & React.KeyboardEvent<HTMLInputElement>) => {
                         if (e.key === 'Enter') {
                           return handleOptionClick(e);
                         }

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -150,7 +150,7 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
             {helpText && helpText !== '' && (
               <div className="md-multiselect__help-button">
                 <MdHelpButton
-                  ariaLabel={`Hjelpetekst for ${label}`}
+                  aria-label={`Hjelpetekst for ${label}`}
                   id={`md-multiselect_help-button_${multiSelectId}`}
                   aria-expanded={helpOpen}
                   aria-controls={`md-multiselect_help-text_${multiSelectId}`}

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -28,7 +28,7 @@ export interface MdMultiSelectProps {
   errorText?: string;
   showChips?: boolean;
   closeOnSelect?: boolean;
-  id?: string | number | null | undefined;
+  id?: string | null | undefined;
   onChange?(_e: React.ChangeEvent): void;
   dropdownHeight?: number;
 }
@@ -187,7 +187,7 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
             aria-expanded={open}
             aria-controls={`md-multiselect_dropdown_${multiSelectId}`}
             aria-labelledby={label && label !== '' ? `md-multiselect_label_${multiSelectId}` : undefined}
-            id={String(multiSelectId) || undefined}
+            id={multiSelectId}
             aria-describedby={helpText && helpText !== '' ? `md-multiselect_help-text_${multiSelectId}` : undefined}
             className={buttonClassNames}
             type="button"

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -22,7 +22,10 @@ export interface MdMultiSelectProps {
   selected?: MdMultiSelectOptionProps[];
   placeholder?: string;
   disabled?: boolean;
-  size?: string;
+  /**
+   * Replaces previous 'size'-prop for reducing overall width of whole component from large to either medium or small.
+   */
+  mode?: 'large' | 'medium' | 'small';
   helpText?: string;
   error?: boolean;
   errorText?: string;
@@ -41,7 +44,7 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
       selected = [],
       placeholder = 'Vennligst velg',
       disabled = false,
-      size,
+      mode = 'large',
       helpText,
       error,
       errorText,
@@ -66,13 +69,13 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
       'md-multiselect--open': !!open,
       'md-multiselect--disabled': !!disabled,
       'md-multiselect--error': !!error,
-      'md-multiselect--medium': size === 'medium',
-      'md-multiselect--small': size === 'small',
+      'md-multiselect--medium': mode === 'medium',
+      'md-multiselect--small': mode === 'small',
     });
 
     const buttonClassNames = classnames('md-multiselect__button', {
       'md-multiselect__button--open': !!open,
-      'md-multiselect--small': size === 'small',
+      'md-multiselect--small': mode === 'small',
     });
 
     const dropDownClassNames = classnames('md-multiselect__dropdown', {

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -28,7 +28,7 @@ export interface MdMultiSelectProps {
   errorText?: string;
   showChips?: boolean;
   closeOnSelect?: boolean;
-  id?: string | null | undefined;
+  id?: string;
   onChange?(_e: React.ChangeEvent): void;
   dropdownHeight?: number;
 }

--- a/packages/react/src/formElements/MdRadioButton.tsx
+++ b/packages/react/src/formElements/MdRadioButton.tsx
@@ -29,8 +29,8 @@ const MdRadioButton: React.FunctionComponent<MdRadioButtonProps> = ({
   return (
     <div className={classNames}>
       <span className="md-radiobutton__check-area">{checked && <span className="md-radiobutton__selected-dot" />}</span>
-      <input id={radioGroupId || undefined} type="radio" checked={checked} disabled={disabled} {...otherProps} />
-      <label htmlFor={String(radioGroupId) || undefined}>{label && label !== '' && label}</label>
+      <input id={radioGroupId} type="radio" checked={checked} disabled={disabled} {...otherProps} />
+      <label htmlFor={radioGroupId}>{label && label !== '' && label}</label>
     </div>
   );
 };

--- a/packages/react/src/formElements/MdRadioButton.tsx
+++ b/packages/react/src/formElements/MdRadioButton.tsx
@@ -3,24 +3,14 @@ import classnames from 'classnames';
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-export interface MdRadioButtonProps {
-  checked?: boolean | undefined;
+export interface MdRadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  value?: any;
-  id?: string | number;
-  disabled?: boolean;
-  className?: string;
-  onChange(_e: React.ChangeEvent<HTMLInputElement>): void;
-  onBlur?(_e: React.FocusEvent<HTMLInputElement>): void;
-  onFocus?(_e: React.FocusEvent<HTMLInputElement>): void;
-  [otherProps: string]: unknown;
 }
 
 const MdRadioButton: React.FunctionComponent<MdRadioButtonProps> = ({
   id,
   disabled,
   className,
-  value,
   label,
   checked,
   ...otherProps
@@ -39,14 +29,7 @@ const MdRadioButton: React.FunctionComponent<MdRadioButtonProps> = ({
   return (
     <div className={classNames}>
       <span className="md-radiobutton__check-area">{checked && <span className="md-radiobutton__selected-dot" />}</span>
-      <input
-        id={String(radioGroupId) || undefined}
-        type="radio"
-        value={value}
-        checked={checked}
-        disabled={disabled}
-        {...otherProps}
-      />
+      <input id={radioGroupId || undefined} type="radio" checked={checked} disabled={disabled} {...otherProps} />
       <label htmlFor={String(radioGroupId) || undefined}>{label && label !== '' && label}</label>
     </div>
   );

--- a/packages/react/src/formElements/MdRadioGroup.tsx
+++ b/packages/react/src/formElements/MdRadioGroup.tsx
@@ -90,7 +90,7 @@ const MdRadioGroup: React.FunctionComponent<MdRadioGroupProps> = ({
 
         {helpText && helpText !== '' && (
           <MdHelpButton
-            ariaLabel={`Hjelpetekst for ${label}`}
+            aria-label={`Hjelpetekst for ${label}`}
             id={`md-radiogroup_help-button_${radioGroupId}`}
             aria-expanded={helpOpen}
             aria-controls={`md-radiogroup_help-text_${radioGroupId}`}

--- a/packages/react/src/formElements/MdRadioGroup.tsx
+++ b/packages/react/src/formElements/MdRadioGroup.tsx
@@ -16,7 +16,7 @@ export interface MdRadioGroupProps {
   options?: MdRadioGroupOption[];
   selectedOption?: any;
   label?: string;
-  id?: string | number;
+  id?: string;
   disabled?: boolean;
   direction?: string;
   className?: string;
@@ -114,7 +114,7 @@ const MdRadioGroup: React.FunctionComponent<MdRadioGroupProps> = ({
       )}
 
       <div
-        id={String(radioGroupId) || undefined}
+        id={radioGroupId}
         aria-describedby={helpText && helpText !== '' ? `md-radiogroup_help-text_${radioGroupId}` : undefined}
         className={optionsClassNames}
       >

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -17,7 +17,7 @@ export interface MdSelectOptionProps {
 export interface MdSelectProps {
   label?: string | null;
   options?: MdSelectOptionProps[];
-  id?: string | null | undefined;
+  id?: string;
   name?: string;
   value?: string | number;
   placeholder?: string;
@@ -36,7 +36,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
       label,
       value,
       options,
-      id = null,
+      id,
       placeholder = 'Vennligst velg',
       disabled = false,
       size,

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -136,7 +136,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
             {helpText && helpText !== '' && (
               <div className="md-select__help-button">
                 <MdHelpButton
-                  ariaLabel={`Hjelpetekst for ${label}`}
+                  aria-label={`Hjelpetekst for ${label}`}
                   id={`md-select_help-button_${selectId}`}
                   aria-expanded={helpOpen}
                   aria-controls={`md-select_help-text_${selectId}`}

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -22,7 +22,10 @@ export interface MdSelectProps {
   value?: string | number;
   placeholder?: string;
   disabled?: boolean;
-  size?: string;
+  /**
+   * Replaces previous 'size'-prop for reducing overall width of whole component from large to either medium or small.
+   */
+  mode?: 'large' | 'medium' | 'small';
   helpText?: string;
   error?: boolean;
   errorText?: string;
@@ -39,7 +42,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
       id,
       placeholder = 'Vennligst velg',
       disabled = false,
-      size,
+      mode = 'large',
       helpText,
       error = false,
       errorText,
@@ -60,8 +63,8 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
       'md-select--open': !!open,
       'md-select--error': !!error,
       'md-select--disabled': !!disabled,
-      'md-select--medium': size === 'medium',
-      'md-select--small': size === 'small',
+      'md-select--medium': mode === 'medium',
+      'md-select--small': mode === 'small',
     });
 
     const selectedOption =
@@ -119,7 +122,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
     const buttonClassNames = classnames('md-select__button', {
       'md-select__button--open': !!open,
       'md-select__button--error': !!error,
-      'md-select__button--small': size === 'small',
+      'md-select__button--small': mode === 'small',
     });
 
     const optionClass = (option: MdSelectOptionProps) => {

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -17,7 +17,7 @@ export interface MdSelectOptionProps {
 export interface MdSelectProps {
   label?: string | null;
   options?: MdSelectOptionProps[];
-  id?: string | number | null | undefined;
+  id?: string | null | undefined;
   name?: string;
   value?: string | number;
   placeholder?: string;
@@ -172,7 +172,7 @@ const MdSelect = React.forwardRef<HTMLButtonElement, MdSelectProps>(
             aria-expanded={open}
             aria-controls={`md-select_dropdown_${selectId}`}
             aria-labelledby={label && label !== '' ? `md-select_label_${selectId}` : undefined}
-            id={String(selectId) || undefined}
+            id={selectId}
             aria-describedby={helpText && helpText !== '' ? `md-select_help-text_${selectId}` : undefined}
             className={buttonClassNames}
             type="button"

--- a/packages/react/src/formElements/MdTextArea.tsx
+++ b/packages/react/src/formElements/MdTextArea.tsx
@@ -51,7 +51,7 @@ const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
           {helpText && helpText !== '' && (
             <div className="md-textarea__help-button">
               <MdHelpButton
-                ariaLabel={`Hjelpetekst for ${label}`}
+                aria-label={`Hjelpetekst for ${label}`}
                 id={`md-textarea_help-button_${textAreaId}`}
                 aria-expanded={helpOpen}
                 aria-controls={`md-textarea_help-text_${textAreaId}`}

--- a/packages/react/src/formElements/MdTextArea.tsx
+++ b/packages/react/src/formElements/MdTextArea.tsx
@@ -5,22 +5,12 @@ import { v4 as uuidv4 } from 'uuid';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 
-export interface MdTextAreaProps {
-  value?: string | undefined;
-  rows?: number;
+export interface MdTextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;
-  id?: string;
-  placeholder?: string;
-  disabled?: boolean;
-  readOnly?: boolean;
   error?: boolean;
   errorText?: string;
   helpText?: string;
   outerWrapperClass?: string;
-  onChange?(_e: React.ChangeEvent<HTMLTextAreaElement>): void;
-  onClick?(_e: React.MouseEvent<HTMLTextAreaElement>): void;
-  onBlur?(_e: React.FocusEvent<HTMLTextAreaElement>): void;
-  onFocus?(_e: React.FocusEvent<HTMLTextAreaElement>): void;
 }
 
 const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
@@ -30,13 +20,13 @@ const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
       id,
       rows = 10,
       value = '',
-      placeholder,
       disabled = false,
       readOnly = false,
       error = false,
       errorText,
       helpText,
       outerWrapperClass = '',
+      className,
       ...otherProps
     },
     ref,
@@ -44,11 +34,15 @@ const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
     const [helpOpen, setHelpOpen] = useState(false);
     const textAreaId = id && id !== '' ? id : uuidv4();
 
-    const classNames = classnames('md-textarea', {
-      'md-textarea--disabled': !!disabled,
-      'md-textarea--readonly': !!readOnly,
-      'md-textarea--error': !!error,
-    });
+    const classNames = classnames(
+      'md-textarea',
+      {
+        'md-textarea--disabled': !!disabled,
+        'md-textarea--readonly': !!readOnly,
+        'md-textarea--error': !!error,
+      },
+      className,
+    );
 
     return (
       <div className={`md-textarea__outer-wrapper ${outerWrapperClass}`}>
@@ -87,7 +81,6 @@ const MdTextArea = React.forwardRef<HTMLTextAreaElement, MdTextAreaProps>(
             value={value}
             rows={rows}
             className={classNames}
-            placeholder={placeholder}
             disabled={!!disabled}
             readOnly={!!readOnly}
             ref={ref}

--- a/packages/react/src/help/MdHelpButton.tsx
+++ b/packages/react/src/help/MdHelpButton.tsx
@@ -5,13 +5,11 @@ import MdHelpIcon from '../icons/MdHelpIcon64';
 export interface MdHelpButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   expanded: boolean;
   hideArrow?: boolean;
-  ariaLabel?: string;
 }
 
 const MdHelpButton: React.FunctionComponent<MdHelpButtonProps> = ({
   className,
   expanded = false,
-  ariaLabel = 'Hjelpetekst',
   hideArrow = false,
   ...otherProps
 }: MdHelpButtonProps) => {
@@ -21,7 +19,7 @@ const MdHelpButton: React.FunctionComponent<MdHelpButtonProps> = ({
   });
 
   return (
-    <button aria-label={ariaLabel} className={buttonClasses} type="button" {...otherProps}>
+    <button aria-label="Hjelpetekst" className={buttonClasses} type="button" {...otherProps}>
       <MdHelpIcon aria-hidden="true" className="md-helpbutton__icon" />
     </button>
   );

--- a/packages/react/src/help/MdHelpButton.tsx
+++ b/packages/react/src/help/MdHelpButton.tsx
@@ -2,20 +2,15 @@ import classnames from 'classnames';
 import React from 'react';
 import MdHelpIcon from '../icons/MdHelpIcon64';
 
-export interface MdHelpButtonProps {
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+export interface MdHelpButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   expanded: boolean;
   hideArrow?: boolean;
-  id?: string;
   ariaLabel?: string;
-  className?: string;
 }
 
 const MdHelpButton: React.FunctionComponent<MdHelpButtonProps> = ({
-  onClick,
   className,
   expanded = false,
-  id,
   ariaLabel = 'Hjelpetekst',
   hideArrow = false,
   ...otherProps
@@ -26,7 +21,7 @@ const MdHelpButton: React.FunctionComponent<MdHelpButtonProps> = ({
   });
 
   return (
-    <button {...otherProps} id={id} aria-label={ariaLabel} className={buttonClasses} onClick={onClick} type="button">
+    <button aria-label={ariaLabel} className={buttonClasses} type="button" {...otherProps}>
       <MdHelpIcon aria-hidden="true" className="md-helpbutton__icon" />
     </button>
   );

--- a/packages/react/src/help/MdHelpText.tsx
+++ b/packages/react/src/help/MdHelpText.tsx
@@ -1,13 +1,18 @@
+import classNames from 'classnames';
 import React from 'react';
 
-export interface MdHelpTextProps {
+export interface MdHelpTextProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode[] | React.ReactNode | string;
-  [otherProps: string]: unknown;
 }
 
-const MdHelpText: React.FunctionComponent<MdHelpTextProps> = ({ children, ...otherProps }: MdHelpTextProps) => {
+const MdHelpText: React.FunctionComponent<MdHelpTextProps> = ({
+  children,
+  className,
+  ...otherProps
+}: MdHelpTextProps) => {
+  const combinedClasses = classNames('md-helptext', className);
   return (
-    <div className="md-helptext" {...otherProps}>
+    <div className={combinedClasses} {...otherProps}>
       {children}
     </div>
   );

--- a/packages/react/src/iconButton/MdIconButton.tsx
+++ b/packages/react/src/iconButton/MdIconButton.tsx
@@ -4,7 +4,6 @@ import MdTooltip from '../tooltip/MdTooltip';
 
 export interface MdIconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   theme?: 'filled' | 'border' | 'plain';
-  ariaLabel: string;
   children?: React.ReactNode;
   disabled?: boolean;
   showTooltip?: boolean;
@@ -13,7 +12,6 @@ export interface MdIconButtonProps extends React.ButtonHTMLAttributes<HTMLButton
 const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   theme,
   children,
-  ariaLabel,
   showTooltip = false,
   disabled,
   type = 'button',
@@ -31,7 +29,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   const button = (
-    <button aria-label={ariaLabel} type={type} disabled={disabled} className={classNames} {...otherProps}>
+    <button type={type} disabled={disabled} className={classNames} {...otherProps}>
       {children && (
         <div aria-hidden="true" className="md-icon-button__icon">
           {children}
@@ -41,7 +39,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   return showTooltip && !disabled ? (
-    <MdTooltip tooltipContent={ariaLabel} aria-label={ariaLabel}>
+    <MdTooltip tooltipContent={otherProps['aria-label']} aria-label={otherProps['aria-label']}>
       {button}
     </MdTooltip>
   ) : (

--- a/packages/react/src/iconButton/MdIconButton.tsx
+++ b/packages/react/src/iconButton/MdIconButton.tsx
@@ -41,7 +41,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   return showTooltip && !disabled ? (
-    <MdTooltip label={ariaLabel} aria-label={ariaLabel}>
+    <MdTooltip tooltipContent={ariaLabel} aria-label={ariaLabel}>
       {button}
     </MdTooltip>
   ) : (

--- a/packages/react/src/iconButton/MdIconButton.tsx
+++ b/packages/react/src/iconButton/MdIconButton.tsx
@@ -8,7 +8,6 @@ export interface MdIconButtonProps extends React.ButtonHTMLAttributes<HTMLButton
   children?: React.ReactNode;
   disabled?: boolean;
   showTooltip?: boolean;
-  type?: 'button' | 'submit' | 'reset' | undefined;
 }
 
 const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
@@ -18,6 +17,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   showTooltip = false,
   disabled,
   type = 'button',
+  className,
   ...otherProps
 }: MdIconButtonProps) => {
   const classNames = classnames(
@@ -27,11 +27,11 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
       'md-icon-button--border': theme === 'border',
       'md-icon-button--plain': theme === 'plain',
     },
-    otherProps.className,
+    className,
   );
 
   const button = (
-    <button aria-label={ariaLabel} type={type} disabled={disabled} {...otherProps} className={classNames}>
+    <button aria-label={ariaLabel} type={type} disabled={disabled} className={classNames} {...otherProps}>
       {children && (
         <div aria-hidden="true" className="md-icon-button__icon">
           {children}
@@ -41,7 +41,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   return showTooltip && !disabled ? (
-    <MdTooltip content={ariaLabel} ariaLabel={ariaLabel}>
+    <MdTooltip label={ariaLabel} aria-label={ariaLabel}>
       {button}
     </MdTooltip>
   ) : (

--- a/packages/react/src/iconButton/MdIconButton.tsx
+++ b/packages/react/src/iconButton/MdIconButton.tsx
@@ -7,6 +7,7 @@ export interface MdIconButtonProps extends React.ButtonHTMLAttributes<HTMLButton
   children?: React.ReactNode;
   disabled?: boolean;
   showTooltip?: boolean;
+  ['aria-label']: string;
 }
 
 const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
@@ -16,6 +17,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   disabled,
   type = 'button',
   className,
+  'aria-label': ariaLabel,
   ...otherProps
 }: MdIconButtonProps) => {
   const classNames = classnames(
@@ -29,7 +31,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   const button = (
-    <button type={type} disabled={disabled} className={classNames} {...otherProps}>
+    <button aria-label={ariaLabel} type={type} disabled={disabled} className={classNames} {...otherProps}>
       {children && (
         <div aria-hidden="true" className="md-icon-button__icon">
           {children}
@@ -39,7 +41,7 @@ const MdIconButton: React.FunctionComponent<MdIconButtonProps> = ({
   );
 
   return showTooltip && !disabled ? (
-    <MdTooltip tooltipContent={otherProps['aria-label']} aria-label={otherProps['aria-label']}>
+    <MdTooltip tooltipContent={ariaLabel} aria-label={ariaLabel}>
       {button}
     </MdTooltip>
   ) : (

--- a/packages/react/src/icons/MdCheckIcon.tsx
+++ b/packages/react/src/icons/MdCheckIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdCheckIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdCheckIcon: React.FunctionComponent<MdCheckIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdCheckIconProps) => {
+const MdCheckIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg
       viewBox="0 0 32 32"

--- a/packages/react/src/icons/MdCheckIcon64.tsx
+++ b/packages/react/src/icons/MdCheckIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdCheckIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdCheckIcon64: React.FunctionComponent<MdCheckIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdCheckIconProps) => {
+const MdCheckIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg
       viewBox="0 0 64 64"

--- a/packages/react/src/icons/MdChevronIcon.tsx
+++ b/packages/react/src/icons/MdChevronIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-interface MdChevronIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdChevronIcon: React.FunctionComponent<MdChevronIconProps> = ({
-  className,
-  ...otherProps
-}: MdChevronIconProps) => {
+const MdChevronIcon: React.FunctionComponent<MdIconProps> = ({ className, ...otherProps }: MdIconProps) => {
   return (
     <svg
       version="1.1"

--- a/packages/react/src/icons/MdChevronIcon64.tsx
+++ b/packages/react/src/icons/MdChevronIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-interface MdChevronIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdChevronIcon64: React.FunctionComponent<MdChevronIconProps> = ({
-  className,
-  ...otherProps
-}: MdChevronIconProps) => {
+const MdChevronIcon64: React.FunctionComponent<MdIconProps> = ({ className, ...otherProps }: MdIconProps) => {
   return (
     <svg
       viewBox="0 0 64 64"

--- a/packages/react/src/icons/MdConfirmIcon.tsx
+++ b/packages/react/src/icons/MdConfirmIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-interface MdConfirmIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdConfirmIcon: React.FunctionComponent<MdConfirmIconProps> = ({
-  className,
-  ...otherProps
-}: MdConfirmIconProps) => {
+const MdConfirmIcon: React.FunctionComponent<MdIconProps> = ({ className, ...otherProps }: MdIconProps) => {
   return (
     <svg
       version="1.1"

--- a/packages/react/src/icons/MdConfirmIcon64.tsx
+++ b/packages/react/src/icons/MdConfirmIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-interface MdConfirmIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdConfirmIcon64: React.FunctionComponent<MdConfirmIconProps> = ({
-  className,
-  ...otherProps
-}: MdConfirmIconProps) => {
+const MdConfirmIcon64: React.FunctionComponent<MdIconProps> = ({ className, ...otherProps }: MdIconProps) => {
   return (
     <svg
       viewBox="0 0 64 64"

--- a/packages/react/src/icons/MdDeleteIcon.tsx
+++ b/packages/react/src/icons/MdDeleteIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDeleteIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDeleteIcon: React.FunctionComponent<MdDeleteIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdDeleteIconProps) => {
+const MdDeleteIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdDeleteIcon64.tsx
+++ b/packages/react/src/icons/MdDeleteIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDeleteIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDeleteIcon64: React.FunctionComponent<MdDeleteIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdDeleteIconProps) => {
+const MdDeleteIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdDocIcon.tsx
+++ b/packages/react/src/icons/MdDocIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDocIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDocIcon: React.FunctionComponent<MdDocIconProps> = ({ className = '', ...otherProps }: MdDocIconProps) => {
+const MdDocIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdDocIcon64.tsx
+++ b/packages/react/src/icons/MdDocIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDocIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDocIcon64: React.FunctionComponent<MdDocIconProps> = ({ className = '', ...otherProps }: MdDocIconProps) => {
+const MdDocIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdDownloadIcon.tsx
+++ b/packages/react/src/icons/MdDownloadIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDownloadIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDownloadIcon: React.FunctionComponent<MdDownloadIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdDownloadIconProps) => {
+const MdDownloadIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdDownloadIcon64.tsx
+++ b/packages/react/src/icons/MdDownloadIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdDownloadIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdDownloadIcon64: React.FunctionComponent<MdDownloadIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdDownloadIconProps) => {
+const MdDownloadIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdGraphIcon.tsx
+++ b/packages/react/src/icons/MdGraphIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdGraphProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdGraphIcon: React.FunctionComponent<MdGraphProps> = ({ className = '', ...otherProps }: MdGraphProps) => {
+const MdGraphIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdGraphIcon64.tsx
+++ b/packages/react/src/icons/MdGraphIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdGraphProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdGraphIcon64: React.FunctionComponent<MdGraphProps> = ({ className = '', ...otherProps }: MdGraphProps) => {
+const MdGraphIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdHelpIcon.tsx
+++ b/packages/react/src/icons/MdHelpIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdHelpIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdHelpIcon: React.FunctionComponent<MdHelpIconProps> = ({ className = '', ...otherProps }: MdHelpIconProps) => {
+const MdHelpIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <circle cx="15.74" cy="15.74" r="14" />

--- a/packages/react/src/icons/MdHelpIcon64.tsx
+++ b/packages/react/src/icons/MdHelpIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdHelpIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdHelpIcon64: React.FunctionComponent<MdHelpIconProps> = ({ className = '', ...otherProps }: MdHelpIconProps) => {
+const MdHelpIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <circle cx="32" cy="32" r="26" />

--- a/packages/react/src/icons/MdLoadingSpinnerIcon.tsx
+++ b/packages/react/src/icons/MdLoadingSpinnerIcon.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-interface MdLoadingIconProps {
-  className?: string;
-  size?: number;
-  [otherProps: string]: unknown;
-}
-
-const MdLoadingSpinnerIcon: React.FunctionComponent<MdLoadingIconProps> = ({
+const MdLoadingSpinnerIcon: React.FunctionComponent<MdIconProps> = ({
   className,
-  size = 100,
+  width = 100,
+  height = 100,
   ...otherProps
-}: MdLoadingIconProps) => {
+}: MdIconProps) => {
   return (
     <svg
       viewBox="0 0 100 100"
@@ -18,8 +14,8 @@ const MdLoadingSpinnerIcon: React.FunctionComponent<MdLoadingIconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
       xmlnsXlink="http://www.w3.org/1999/xlink"
       className={className}
-      width={size}
-      height={size}
+      width={width}
+      height={height}
       {...otherProps}
     >
       <circle cx="50" cy="90" r="10" fill="#CCDFDE" />

--- a/packages/react/src/icons/MdMinusIcon.tsx
+++ b/packages/react/src/icons/MdMinusIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdMinusIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdMinusIcon: React.FunctionComponent<MdMinusIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdMinusIconProps) => {
+const MdMinusIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path d="M24.592 16H8V17.6H24.592V16Z" fill="currentColor" />

--- a/packages/react/src/icons/MdMinusIcon64.tsx
+++ b/packages/react/src/icons/MdMinusIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdMinusIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdMinusIcon64: React.FunctionComponent<MdMinusIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdMinusIconProps) => {
+const MdMinusIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path d="M47 31H15V33H47V31Z" fill="currentColor" />

--- a/packages/react/src/icons/MdPlusIcon.tsx
+++ b/packages/react/src/icons/MdPlusIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdPlusIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdPlusIcon: React.FunctionComponent<MdPlusIconProps> = ({ className = '', ...otherProps }: MdPlusIconProps) => {
+const MdPlusIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdPlusIcon64.tsx
+++ b/packages/react/src/icons/MdPlusIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdPlusIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdPlusIcon64: React.FunctionComponent<MdPlusIconProps> = ({ className = '', ...otherProps }: MdPlusIconProps) => {
+const MdPlusIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path d="M48 31.036H32.964V16H31.036V31.036H16V32.964H31.036V48H32.964V32.964H48V31.036Z" fill="currentColor" />

--- a/packages/react/src/icons/MdUploadIcon.tsx
+++ b/packages/react/src/icons/MdUploadIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdUploadIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdUploadIcon: React.FunctionComponent<MdUploadIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdUploadIconProps) => {
+const MdUploadIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdUploadIcon64.tsx
+++ b/packages/react/src/icons/MdUploadIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdUploadIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdUploadIcon64: React.FunctionComponent<MdUploadIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdUploadIconProps) => {
+const MdUploadIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdUserIcon.tsx
+++ b/packages/react/src/icons/MdUserIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdUserIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdUserIcon: React.FunctionComponent<MdUserIconProps> = ({ className = '', ...otherProps }: MdUserIconProps) => {
+const MdUserIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdUserIcon64.tsx
+++ b/packages/react/src/icons/MdUserIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdUserIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdUserIcon64: React.FunctionComponent<MdUserIconProps> = ({ className = '', ...otherProps }: MdUserIconProps) => {
+const MdUserIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" className={className} {...otherProps}>
       <g>

--- a/packages/react/src/icons/MdWarningIcon.tsx
+++ b/packages/react/src/icons/MdWarningIcon.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdWarningIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdWarningIcon: React.FunctionComponent<MdWarningIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdWarningIconProps) => {
+const MdWarningIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdWarningIcon64.tsx
+++ b/packages/react/src/icons/MdWarningIcon64.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdWarningIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdWarningIcon64: React.FunctionComponent<MdWarningIconProps> = ({
-  className = '',
-  ...otherProps
-}: MdWarningIconProps) => {
+const MdWarningIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdXIcon.tsx
+++ b/packages/react/src/icons/MdXIcon.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdXIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdXIcon: React.FunctionComponent<MdXIconProps> = ({ className = '', ...otherProps }: MdXIconProps) => {
+const MdXIcon: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/MdXIcon64.tsx
+++ b/packages/react/src/icons/MdXIcon64.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import type MdIconProps from './icon.model';
 
-export interface MdXIconProps {
-  className?: string;
-  [otherProps: string]: unknown;
-}
-
-const MdXIcon64: React.FunctionComponent<MdXIconProps> = ({ className = '', ...otherProps }: MdXIconProps) => {
+const MdXIcon64: React.FunctionComponent<MdIconProps> = ({ className = '', ...otherProps }: MdIconProps) => {
   return (
     <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className} {...otherProps}>
       <path

--- a/packages/react/src/icons/icon.model.ts
+++ b/packages/react/src/icons/icon.model.ts
@@ -1,6 +1,5 @@
-export interface MdIconProps {
+export interface MdIconProps extends React.SVGAttributes<SVGElement> {
   className?: string;
-  [otherProps: string]: unknown;
 }
 
 export default MdIconProps;

--- a/packages/react/src/infoTag/MdInfoTag.tsx
+++ b/packages/react/src/infoTag/MdInfoTag.tsx
@@ -64,7 +64,7 @@ const MdInfoTag: React.FC<MdInfoTagProps> = ({
     }
   };
   return onClick ? (
-    <button onClick={onClick} {...otherProps} className={classNames}>
+    <button type="button" onClick={onClick} {...otherProps} className={classNames}>
       <div className={labelClassNames}>{label}</div>
 
       <div className="md-info-tag__icon">{renderIcon()}</div>

--- a/packages/react/src/infoTag/MdInfoTag.tsx
+++ b/packages/react/src/infoTag/MdInfoTag.tsx
@@ -9,7 +9,7 @@ import MdWarningIcon from '../icons/MdWarningIcon';
 type ThemeTypes = null | undefined | '' | 'primary' | 'secondary' | 'warning' | 'danger' | 'success';
 type IconTypes = null | undefined | '' | 'none' | 'info' | 'warning' | 'error' | 'check' | 'custom';
 
-export interface MdInfoTagProps {
+export interface MdInfoTagProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   theme?: ThemeTypes;
   keepOpen?: boolean;
   label?: string;
@@ -19,7 +19,7 @@ export interface MdInfoTagProps {
   onClick?(_e: React.MouseEvent): void;
 }
 
-const MdInfoTag: React.FC<MdInfoTagProps & React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
+const MdInfoTag: React.FC<MdInfoTagProps> = ({
   theme = 'primary',
   keepOpen = false,
   icon = 'none',
@@ -27,15 +27,20 @@ const MdInfoTag: React.FC<MdInfoTagProps & React.ButtonHTMLAttributes<HTMLButton
   label,
   outline = false,
   onClick = undefined,
-}: MdInfoTagProps & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
-  const classNames = classnames('md-info-tag', {
-    'md-info-tag--secondary': theme === 'secondary',
-    'md-info-tag--warning': theme === 'warning',
-    'md-info-tag--danger': theme === 'danger',
-    'md-info-tag--success': theme === 'success',
-    'md-info-tag--outline': outline,
-    'md-info-tag--button': onClick,
-  });
+  ...otherProps
+}: MdInfoTagProps) => {
+  const classNames = classnames(
+    'md-info-tag',
+    {
+      'md-info-tag--secondary': theme === 'secondary',
+      'md-info-tag--warning': theme === 'warning',
+      'md-info-tag--danger': theme === 'danger',
+      'md-info-tag--success': theme === 'success',
+      'md-info-tag--outline': outline,
+      'md-info-tag--button': onClick,
+    },
+    otherProps.className,
+  );
 
   const labelClassNames = classnames('md-info-tag__label', {
     'md-info-tag__label--show': keepOpen,
@@ -59,7 +64,7 @@ const MdInfoTag: React.FC<MdInfoTagProps & React.ButtonHTMLAttributes<HTMLButton
     }
   };
   return onClick ? (
-    <button type="button" onClick={onClick} className={classNames}>
+    <button onClick={onClick} {...otherProps} className={classNames}>
       <div className={labelClassNames}>{label}</div>
 
       <div className="md-info-tag__icon">{renderIcon()}</div>

--- a/packages/react/src/loadingSpinner/MdLoadingSpinner.tsx
+++ b/packages/react/src/loadingSpinner/MdLoadingSpinner.tsx
@@ -2,16 +2,16 @@ import classnames from 'classnames';
 import React from 'react';
 import MdLoadingSpinnerIcon from '../icons/MdLoadingSpinnerIcon';
 
-export interface MdLoadingSpinnerProps {
+export interface MdLoadingSpinnerProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: number;
   position?: string;
-  className?: string;
 }
 
 const MdLoadingSpinner: React.FC<MdLoadingSpinnerProps> = ({
   size,
   position = '',
   className = '',
+  ...otherProps
 }: MdLoadingSpinnerProps) => {
   const classNames = classnames(
     'md-loading-spinner__container',
@@ -23,8 +23,8 @@ const MdLoadingSpinner: React.FC<MdLoadingSpinnerProps> = ({
   );
 
   return (
-    <div aria-label="Laster" className={classNames}>
-      <MdLoadingSpinnerIcon className="md-loading-spinner" size={size} />
+    <div aria-label="Laster" className={classNames} {...otherProps}>
+      <MdLoadingSpinnerIcon className="md-loading-spinner" width={size} height={size} />
     </div>
   );
 };

--- a/packages/react/src/messages/MdAlertMessage.tsx
+++ b/packages/react/src/messages/MdAlertMessage.tsx
@@ -6,7 +6,7 @@ import MdInfoIcon from '../icons/MdInfoIcon';
 import MdWarningIcon from '../icons/MdWarningIcon';
 import MdXIcon from '../icons/MdXIcon';
 
-export interface MdAlertMessageProps {
+export interface MdAlertMessageProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: 'info' | 'confirm' | 'warning' | 'error';
   label?: string | React.ReactNode;
   hideIcon?: boolean;
@@ -16,7 +16,6 @@ export interface MdAlertMessageProps {
   customIcon?: React.ReactNode | string;
   className?: string;
   alignContent?: 'start' | 'center' | 'end';
-  role?: React.AriaRole;
 }
 
 const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
@@ -29,7 +28,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   customIcon,
   className,
   alignContent,
-  role,
+  ...otherProps
 }: MdAlertMessageProps) => {
   const classNames = classnames(
     'md-alert-message',
@@ -68,7 +67,7 @@ const MdAlertMessage: React.FC<MdAlertMessageProps> = ({
   };
 
   return (
-    <div className={classNames} role={role}>
+    <div className={classNames} {...otherProps}>
       <div className={contentClassNames}>
         {!hideIcon && renderIcon()}
         {label}

--- a/packages/react/src/messages/MdInfoBox.tsx
+++ b/packages/react/src/messages/MdInfoBox.tsx
@@ -2,12 +2,11 @@ import classnames from 'classnames';
 import React from 'react';
 import MdInfoIcon from '../icons/MdInfoIcon';
 
-export interface MdInfoBoxProps {
+export interface MdInfoBoxProps extends React.HTMLAttributes<HTMLDivElement> {
   label: string;
   hideIcon?: boolean;
   fullWidth?: boolean;
   customIcon?: React.ReactNode | string;
-  role?: React.AriaRole;
 }
 
 const MdInfoBox: React.FC<MdInfoBoxProps> = ({
@@ -15,11 +14,16 @@ const MdInfoBox: React.FC<MdInfoBoxProps> = ({
   hideIcon = false,
   fullWidth = false,
   customIcon,
-  role,
+  className,
+  ...otherProps
 }: MdInfoBoxProps) => {
-  const classNames = classnames('md-info-box', {
-    'md-info-box--fullWidth': !!fullWidth,
-  });
+  const classNames = classnames(
+    'md-info-box',
+    {
+      'md-info-box--fullWidth': !!fullWidth,
+    },
+    className,
+  );
 
   const renderIcon = () => {
     let icon = (<MdInfoIcon aria-label="Info" width="20" height="20" />) as React.ReactNode;
@@ -30,7 +34,7 @@ const MdInfoBox: React.FC<MdInfoBoxProps> = ({
   };
 
   return (
-    <div className={classNames} role={role}>
+    <div className={classNames} {...otherProps}>
       {!hideIcon && renderIcon()}
       {label}
     </div>

--- a/packages/react/src/modal/MdModal.tsx
+++ b/packages/react/src/modal/MdModal.tsx
@@ -12,7 +12,6 @@ export interface MdModalProps {
   children: any;
   heading?: string;
   headingIcon?: React.ReactNode | string;
-  id?: any;
   open?: boolean;
   error?: boolean;
   className?: string;

--- a/packages/react/src/tiles/MdTile.tsx
+++ b/packages/react/src/tiles/MdTile.tsx
@@ -20,10 +20,15 @@ const MdTile: React.FC<MdTileProps> = ({
   icon = null,
   preventDefault = false,
   onClick,
-}: MdTileProps) => {
-  const classNames = classnames('md-tile', {
-    'md-tile--disabled': !!disabled,
-  });
+  ...otherProps
+}: MdTileProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const classNames = classnames(
+    'md-tile',
+    {
+      'md-tile--disabled': !!disabled,
+    },
+    otherProps.className,
+  );
 
   const handleClick = (e: React.MouseEvent) => {
     if (preventDefault || disabled) {
@@ -50,11 +55,18 @@ const MdTile: React.FC<MdTileProps> = ({
   );
 
   return href ? (
-    <a className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
+    <a {...otherProps} className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
       {content}
     </a>
   ) : (
-    <button disabled={disabled} type="button" className={classNames} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
+    <button
+      type="button"
+      {...otherProps}
+      disabled={disabled}
+      className={classNames}
+      onClick={handleClick}
+      tabIndex={disabled ? -1 : 0}
+    >
       {content}
     </button>
   );

--- a/packages/react/src/tiles/MdTileVertical.tsx
+++ b/packages/react/src/tiles/MdTileVertical.tsx
@@ -21,12 +21,19 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   icon = null,
   preventDefault = false,
   onClick,
-}: MdTileVerticalProps) => {
-  const classNames = classnames('md-tile-vertical', {
-    'md-tile-vertical--disabled': !!disabled,
-    'md-tile-vertical--small': size === 'small',
-    'md-tile-vertical--large': size === 'large',
-  });
+  ...otherProps
+}: MdTileVerticalProps &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  const classNames = classnames(
+    'md-tile-vertical',
+    {
+      'md-tile-vertical--disabled': !!disabled,
+      'md-tile-vertical--small': size === 'small',
+      'md-tile-vertical--large': size === 'large',
+    },
+    otherProps.className,
+  );
 
   const handleClick = (e: React.MouseEvent) => {
     if (preventDefault || disabled) {
@@ -50,11 +57,18 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   );
 
   return href ? (
-    <a className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
+    <a {...otherProps} className={classNames} href={href || '#'} tabIndex={disabled ? -1 : 0}>
       {content}
     </a>
   ) : (
-    <button disabled={disabled} type="button" className={classNames} onClick={handleClick} tabIndex={disabled ? -1 : 0}>
+    <button
+      type="button"
+      {...otherProps}
+      disabled={disabled}
+      className={classNames}
+      onClick={handleClick}
+      tabIndex={disabled ? -1 : 0}
+    >
       {content}
     </button>
   );

--- a/packages/react/src/tiles/MdTileVertical.tsx
+++ b/packages/react/src/tiles/MdTileVertical.tsx
@@ -4,7 +4,10 @@ import React from 'react';
 export interface MdTileVerticalProps {
   heading?: string;
   description?: string;
-  size?: string;
+  /**
+   * Replaces previous 'size'-prop for controlling width of component from medium to either large or small.
+   */
+  mode?: 'large' | 'medium' | 'small';
   disabled?: boolean;
   href?: string;
   icon?: React.ReactNode;
@@ -15,7 +18,7 @@ export interface MdTileVerticalProps {
 const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   heading,
   description,
-  size,
+  mode = 'medium',
   disabled = false,
   href,
   icon = null,
@@ -29,8 +32,8 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
     'md-tile-vertical',
     {
       'md-tile-vertical--disabled': !!disabled,
-      'md-tile-vertical--small': size === 'small',
-      'md-tile-vertical--large': size === 'large',
+      'md-tile-vertical--small': mode === 'small',
+      'md-tile-vertical--large': mode === 'large',
     },
     otherProps.className,
   );

--- a/packages/react/src/toggle/MdToggle.tsx
+++ b/packages/react/src/toggle/MdToggle.tsx
@@ -1,13 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
-import type { ChangeEvent } from 'react';
-
 export interface MdToggleProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  checked: boolean;
-  id: string;
-  onChange(_e: ChangeEvent<HTMLInputElement>): void;
   label?: string;
-  disabled?: boolean;
   error?: boolean;
   errorText?: string | undefined;
   wrapperClass?: string;
@@ -21,7 +15,7 @@ const MdToggle: React.FunctionComponent<MdToggleProps> = ({
   error = false,
   errorText = undefined,
   wrapperClass = '',
-  onChange,
+  ...otherProps
 }: MdToggleProps) => {
   const classNames = classnames('md-toggle__label', {
     'md-toggle__label--error': !!error,
@@ -35,10 +29,6 @@ const MdToggle: React.FunctionComponent<MdToggleProps> = ({
 
   const outerWrapperClassNames = classnames('md-toggle__wrapper', wrapperClass);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    onChange(e);
-  };
-
   return (
     <div>
       <div className={outerWrapperClassNames}>
@@ -48,10 +38,8 @@ const MdToggle: React.FunctionComponent<MdToggleProps> = ({
           id={id}
           type="checkbox"
           checked={checked}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            return handleChange(e);
-          }}
           disabled={disabled}
+          {...otherProps}
         />
         <label className={labelWrapperClassNames} htmlFor={id}>
           <div className="md-toggle__label-text">{label}</div>

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -8,7 +8,6 @@ export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   tooltipContent: React.ReactNode;
   position?: 'top' | 'bottom' | 'right' | 'left';
-  ariaLabel?: string;
   children?: React.ReactNode;
 }
 
@@ -16,7 +15,6 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
   tooltipContent,
   position = 'bottom',
   children,
-  ariaLabel,
   ...otherProps
 }: MdTooltipProps) => {
   const [hover, setHover] = useState(false);
@@ -45,7 +43,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
   };
 
   return (
-    <div aria-label={ariaLabel} {...otherProps}>
+    <div {...otherProps}>
       <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -8,6 +8,7 @@ export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   tooltipContent: React.ReactNode;
   position?: 'top' | 'bottom' | 'right' | 'left';
+  ['aria-label']: string;
   children?: React.ReactNode;
   tooltipClass?: string;
 }
@@ -16,6 +17,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
   tooltipContent,
   position = 'bottom',
   children,
+  'aria-label': ariaLabel,
   tooltipClass,
   ...otherProps
 }: MdTooltipProps) => {
@@ -46,7 +48,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
   };
 
   return (
-    <div {...otherProps}>
+    <div aria-label={ariaLabel} {...otherProps}>
       <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -6,14 +6,14 @@ export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
    * Replaces previous content-prop for specifying the content of the tooltip.
    * Content-prop is reserved as a standard HTML attribute on div-elements.
    */
-  label: React.ReactNode;
+  tooltipContent: React.ReactNode;
   position?: 'top' | 'bottom' | 'right' | 'left';
   ariaLabel?: string;
   children?: React.ReactNode;
 }
 
 const MdTooltip: React.FC<MdTooltipProps> = ({
-  label,
+  tooltipContent,
   position = 'bottom',
   children,
   ariaLabel,
@@ -49,7 +49,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
       <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>
-      <div className={classNames}>{label}</div>
+      <div className={classNames}>{tooltipContent}</div>
     </div>
   );
 };

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -1,14 +1,24 @@
 import classnames from 'classnames';
 import React, { useState } from 'react';
 
-export interface MdTooltipProps {
-  content: React.ReactNode;
+export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Replaces previous content-prop for specifying the content of the tooltip.
+   * Content-prop is reserved as a standard HTML attribute on div-elements.
+   */
+  label: React.ReactNode;
   position?: 'top' | 'bottom' | 'right' | 'left';
-  ariaLabel: string;
+  ariaLabel?: string;
   children?: React.ReactNode;
 }
 
-const MdTooltip: React.FC<MdTooltipProps> = ({ content, position = 'bottom', children, ariaLabel }: MdTooltipProps) => {
+const MdTooltip: React.FC<MdTooltipProps> = ({
+  label,
+  position = 'bottom',
+  children,
+  ariaLabel,
+  ...otherProps
+}: MdTooltipProps) => {
   const [hover, setHover] = useState(false);
   const classNames = classnames('md-tooltip', {
     'md-tooltip--show': hover,
@@ -35,11 +45,11 @@ const MdTooltip: React.FC<MdTooltipProps> = ({ content, position = 'bottom', chi
   };
 
   return (
-    <div aria-label={ariaLabel}>
+    <div aria-label={ariaLabel} {...otherProps}>
       <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>
-      <div className={classNames}>{content}</div>
+      <div className={classNames}>{label}</div>
     </div>
   );
 };

--- a/stories/AccordionItem.stories.tsx
+++ b/stories/AccordionItem.stories.tsx
@@ -43,7 +43,7 @@ export default {
       control: { type: 'text' },
     },
     id: {
-      type: { name: 'string | number' },
+      type: { name: 'string' },
       description: 'The id for the accordion item.',
       table: {
         defaultValue: { summary: 'null' },
@@ -55,7 +55,8 @@ export default {
     },
     expanded: {
       type: { name: 'boolean' },
-      description: 'Determines if the accordion is expanded. If not present, component handles expand/collapse internally.',
+      description:
+        'Determines if the accordion is expanded. If not present, component handles expand/collapse internally.',
       table: {
         defaultValue: { summary: 'false' },
         type: {

--- a/stories/Autocomplete.stories.tsx
+++ b/stories/Autocomplete.stories.tsx
@@ -72,7 +72,7 @@ export default {
       control: { type: 'text' },
     },
     id: {
-      type: { name: 'string | number' },
+      type: { name: 'string' },
       description: 'Id for the autocomplete box. If not set, uses a random uuid',
       table: {
         defaultValue: { summary: 'uuid()' },

--- a/stories/Autocomplete.stories.tsx
+++ b/stories/Autocomplete.stories.tsx
@@ -26,7 +26,7 @@ export default {
       },
       description: {
         component:
-          "A form component for single autocomplete.<br/><br/>`import { MdAutocomplete } from '@miljodirektoratet/md-react'`",
+          "A form component for single autocomplete. In addition to the properties presented here, the component accepts all standard attributes of a HTML Input element.<br/><br/>`import { MdAutocomplete } from '@miljodirektoratet/md-react'`",
       },
     },
   },
@@ -91,9 +91,9 @@ export default {
       },
       control: { type: 'boolean' },
     },
-    size: {
-      description: 'Set size og autocomplete box',
-      options: ['large', 'medium', 'small'],
+    mode: {
+      description: 'Set size-mode of autocomplete box',
+      options: ['full', 'medium', 'small'],
       table: {
         defaultValue: { summary: 'large' },
         type: {
@@ -134,9 +134,9 @@ export default {
       },
       control: { type: 'text' },
     },
-    onChange: {
+    onSelectOption: {
       type: { name: 'function' },
-      description: 'The onChange handler for change events. Returns the clicked option, to handle as you please.',
+      description: 'The onSelectOption handler for change events. Returns the clicked option, to handle as you please.',
       table: {
         type: {
           summary: 'function',
@@ -165,7 +165,7 @@ export default {
       },
       control: { type: 'number' },
     },
-    inputRef: {
+    ref: {
       type: { name: 'Ref<HTMLButtonElement>' },
       description:
         // eslint-disable-next-line quotes
@@ -184,7 +184,7 @@ const Template = (args: MdAutocompleteProps) => {
 
   return (
     <div style={{ minHeight: '300px' }}>
-      <MdAutocomplete {...args} onChange={handleChange} />
+      <MdAutocomplete {...args} onSelectOption={handleChange} />
     </div>
   );
 };

--- a/stories/Autocomplete.stories.tsx
+++ b/stories/Autocomplete.stories.tsx
@@ -92,8 +92,8 @@ export default {
       control: { type: 'boolean' },
     },
     mode: {
-      description: 'Set size-mode of autocomplete box',
-      options: ['full', 'medium', 'small'],
+      description: 'Set width of autocomplete box',
+      options: ['large', 'medium', 'small'],
       table: {
         defaultValue: { summary: 'large' },
         type: {
@@ -206,7 +206,7 @@ Autocomplete.args = {
   value: 'optionA',
   id: '',
   disabled: false,
-  size: 'large',
+  mode: 'large',
   helpText: '',
   error: false,
   errorText: '',

--- a/stories/Checkbox.stories.tsx
+++ b/stories/Checkbox.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A checkbox component.<br/><br/>`import { MdCheckbox } from '@miljodirektoratet/md-react'`",
+          "A checkbox component. In addition to the properties presented here, the component accepts all standard attributes of a HTML Input element.<br/><br/>`import { MdCheckbox } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/CheckboxGroup.stories.tsx
+++ b/stories/CheckboxGroup.stories.tsx
@@ -71,12 +71,12 @@ export default {
       control: { type: 'boolean' },
     },
     id: {
-      type: { name: 'number | string' },
+      type: { name: 'string' },
       description: 'The unique id for checkbox group.',
       table: {
         defaultValue: { summary: 'uuidv4' },
         type: {
-          summary: 'number | string',
+          summary: 'string',
         },
       },
       control: { type: 'text' },

--- a/stories/ChipsStories/FilterChip.stories.tsx
+++ b/stories/ChipsStories/FilterChip.stories.tsx
@@ -26,7 +26,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A chip component used for filters. Requires an onClick handler.<br/><br/>`import { MdFilterChip } from '@miljodirektoratet/md-react'`",
+          "A chip component used for filters. In addition to the properties presented here, the component accepts all standard attributes of a HTML Button element.<br/><br/>`import { MdFilterChip } from '@miljodirektoratet/md-react'`",
       },
     },
   },
@@ -83,7 +83,7 @@ export default {
       control: { type: 'boolean' },
     },
     onClick: {
-      type: { name: 'function', required: true },
+      type: { name: 'function' },
       description: 'Callback for click handling.',
       table: {
         type: {

--- a/stories/ChipsStories/InputChip.stories.tsx
+++ b/stories/ChipsStories/InputChip.stories.tsx
@@ -26,7 +26,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A chip component. Requires an onClick handler. In this example clicks toggle active state.<br/><br/>`import { MdInputChip } from '@miljodirektoratet/md-react'`",
+          "A chip component. In addition to the properties presented here, the component accepts all standard attributes of a HTML Button element. In this example clicks toggle active state.<br/><br/>`import { MdInputChip } from '@miljodirektoratet/md-react'`",
       },
     },
   },
@@ -102,7 +102,7 @@ export default {
       control: { type: 'boolean' },
     },
     onClick: {
-      type: { name: 'function', required: true },
+      type: { name: 'function' },
       description: 'Callback for click handling.',
       table: {
         defaultValue: { summary: 'function' },

--- a/stories/HelpStories/HelpButton.stories.tsx
+++ b/stories/HelpStories/HelpButton.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Button for help text. Mainly used in conjunction with MdHelpText.<br/><br/>`import { MdHelpButton } from '@miljodirektoratet/md-react'`",
+          "Button for help text. Mainly used in conjunction with MdHelpText. In addition to the properties presented here, the component accepts all standard attributes of a HTML Button element.<br/><br/>`import { MdHelpButton } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/HelpStories/HelpButton.stories.tsx
+++ b/stories/HelpStories/HelpButton.stories.tsx
@@ -48,7 +48,7 @@ export default {
       },
       control: { type: 'boolean' },
     },
-    ariaLabel: {
+    'aria-label': {
       description: 'Aria label',
       table: {
         type: {

--- a/stories/HelpStories/HelpText.stories.tsx
+++ b/stories/HelpStories/HelpText.stories.tsx
@@ -24,7 +24,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Component for displaying help text, mainly used in conjunction with MdHelpButton.<br/><br/>`import { MdHelpText } from '@miljodirektoratet/md-react'`",
+          "Component for displaying help text, mainly used in conjunction with MdHelpButton. In addition to the properties presented here, the component accepts all standard attributes of a HTML Div element.<br/><br/>`import { MdHelpText } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/IconButton.stories.tsx
+++ b/stories/IconButton.stories.tsx
@@ -42,7 +42,7 @@ export default {
       control: { type: 'inline-radio' },
       if: { arg: 'theme', exists: true },
     },
-    ariaLabel: {
+    'aria-label': {
       description: 'The aria label for the tooltip',
       table: {
         type: {
@@ -75,7 +75,7 @@ export default {
 const Template = (args: MdIconButtonProps) => {
   return (
     <MdIconButton
-      ariaLabel="Last ned filen"
+      aria-label={args['aria-label']}
       showTooltip={args.showTooltip}
       onClick={action(args.theme || '')}
       disabled={args.disabled}
@@ -89,7 +89,7 @@ const Template = (args: MdIconButtonProps) => {
 export const Filled = Template.bind({});
 Filled.args = {
   theme: 'filled',
-  ariaLabel: 'Last ned filen',
+  'aria-label': 'Last ned filen',
   showTooltip: true,
   disabled: false,
 };
@@ -97,7 +97,7 @@ Filled.args = {
 export const Border = Template.bind({});
 Border.args = {
   theme: 'border',
-  ariaLabel: 'Last ned filen',
+  'aria-label': 'Last ned filen',
   showTooltip: true,
   disabled: false,
 };
@@ -105,7 +105,7 @@ Border.args = {
 export const Plain = Template.bind({});
 Plain.args = {
   theme: 'plain',
-  ariaLabel: 'Last ned filen',
+  'aria-label': 'Last ned filen',
   showTooltip: true,
   disabled: false,
 };

--- a/stories/IconButton.stories.tsx
+++ b/stories/IconButton.stories.tsx
@@ -24,8 +24,9 @@ export default {
         );
       },
       description: {
-        // eslint-disable-next-line quotes
-        component: "An icon button component.<br/><br/>`import { MdIconButton } from '@miljodirektoratet/md-react'`",
+        component:
+          // eslint-disable-next-line quotes
+          "An icon button component. In addition to the properties presented here, the component accepts all standard attributes of a HTML Button element.<br/><br/>`import { MdIconButton } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/AllIconsGallery.stories.tsx
+++ b/stories/Icons/AllIconsGallery.stories.tsx
@@ -49,163 +49,163 @@ const Template = (args: Args) => {
   return (
     <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fit, 10rem)' }}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdBurgerMenuIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdBurgerMenuIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdBurgerMenuIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCalendarDayIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCalendarDayIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCalendarDayIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCalendarIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCalendarIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCalendarIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCancelIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCancelIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCancelIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCheckCircleIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCheckCircleIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCheckCircleIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCheckIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCheckIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCheckIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdChevronIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdChevronIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdChevronIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCloseIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCloseIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCloseIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdCommentIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdCommentIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdCommentIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdConfirmIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdConfirmIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdConfirmIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdDeleteIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdDeleteIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdDeleteIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdDocIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdDocIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdDocIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdDocSearchIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdDocSearchIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdDocSearchIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdDownloadIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdDownloadIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdDownloadIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdEditIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdEditIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdEditIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdEnvelopeIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdEnvelopeIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdEnvelopeIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdExpandIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdExpandIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdExpandIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdGraphIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdGraphIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdGraphIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdHelpIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdHelpIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdHelpIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdHomeIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdHomeIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdHomeIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdImageIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdImageIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdImageIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdInfoIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdInfoIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdInfoIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdMinusIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdMinusIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdMinusIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdPanIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdPanIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdPanIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdPersonIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdPersonIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdPersonIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdPinIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdPinIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdPinIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdPlusIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdPlusIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdPlusIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdPrintIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdPrintIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdPrintIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdRedirectIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdRedirectIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdRedirectIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdSettingsIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdSettingsIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdSettingsIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdSignIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdSignIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdSignIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdSortingIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdSortingIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdSortingIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdSubmenuIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdSubmenuIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdSubmenuIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdTableIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdTableIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdTableIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdTimeIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdTimeIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdTimeIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdUploadIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdUploadIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdUploadIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdUserIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdUserIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdUserIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdWarningIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdWarningIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdWarningIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdXIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdXIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdXIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
-        <MdZoomIcon style={{ width: '32px', height: '32px', color: args.color }} className={args.className} />
+        <MdZoomIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdZoomIcon</span>
       </div>
     </div>
@@ -215,5 +215,7 @@ const Template = (args: Args) => {
 export const Gallery = Template.bind({});
 Gallery.args = {
   color: '#005e5d',
+  width: 32,
+  height: 32,
   className: '',
 };

--- a/stories/Icons/BurgerMenuIcon.stories.tsx
+++ b/stories/Icons/BurgerMenuIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Burger menu icon. Color is inherited from parent.<br/><br/>`import { MdBurgerMenuIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdBurgerMenuIcon64 } from '@miljodirektoratet/md-react'`",
+          "Burger menu icon. Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdBurgerMenuIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdBurgerMenuIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CalendarDayIcon.stories.tsx
+++ b/stories/Icons/CalendarDayIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Calendar day icon. Color is inherited from parent.<br/><br/>`import { MdCalendarDayIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCalendarDayIcon64 } from '@miljodirektoratet/md-react'`",
+          "Calendar day icon. Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCalendarDayIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCalendarDayIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CalendarIcon.stories.tsx
+++ b/stories/Icons/CalendarIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Calendar icon. Color is inherited from parent.<br/><br/>`import { MdCalendarIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCalendarIcon64 } from '@miljodirektoratet/md-react'`",
+          "Calendar icon. Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCalendarIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCalendarIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CancelIcon.stories.tsx
+++ b/stories/Icons/CancelIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Cancel icon. Color is inherited from parent.<br/><br/>`import { MdCancelIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCancelIcon64 } from '@miljodirektoratet/md-react'`",
+          "Cancel icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCancelIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCancelIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CheckCircleIcon.stories.tsx
+++ b/stories/Icons/CheckCircleIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Circle with checkmark icon. Color is inherited from parent.<br/><br/>`import { MdCheckCircleIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCheckCircleIcon64 } from '@miljodirektoratet/md-react'`",
+          "Circle with checkmark icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCheckCircleIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCheckCircleIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CheckIcon.stories.tsx
+++ b/stories/Icons/CheckIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Check mark icon. Color is inherited from parent.<br/><br/>`import { MdCheckIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCheckIcon64 } from '@miljodirektoratet/md-react'`",
+          "Check mark icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCheckIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCheckIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/ChevronIcon.stories.tsx
+++ b/stories/Icons/ChevronIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Chevron icon. Color is inherited from parent.<br/><br/>`import { MdChevronIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdChevronIcon64 } from '@miljodirektoratet/md-react'`",
+          "Chevron icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdChevronIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdChevronIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CloseIcon.stories.tsx
+++ b/stories/Icons/CloseIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Close icon. Color is inherited from parent.<br/><br/>`import { MdCloseIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCloseIcon64 } from '@miljodirektoratet/md-react'`",
+          "Close icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCloseIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCloseIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/CommentIcon.stories.tsx
+++ b/stories/Icons/CommentIcon.stories.tsx
@@ -14,7 +14,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Comment icon. Color is inherited from parent.<br/><br/>`import { MdCommentIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentIcon64 } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentFillIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentFillIcon64 } from '@miljodirektoratet/md-react'`",
+          "Comment icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdCommentIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentIcon64 } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentFillIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdCommentFillIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/ConfirmIcon.stories.tsx
+++ b/stories/Icons/ConfirmIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Confirm icon. Color is inherited from parent.<br/><br/>`import { MdConfirmIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdConfirmIcon64 } from '@miljodirektoratet/md-react'`",
+          "Confirm icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdConfirmIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdConfirmIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/DeleteIcon.stories.tsx
+++ b/stories/Icons/DeleteIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Delete icon. Color is inherited from parent.<br/><br/>`import { MdDeleteIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDeleteIcon64 } from '@miljodirektoratet/md-react'`",
+          "Delete icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdDeleteIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDeleteIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/DocIcon.stories.tsx
+++ b/stories/Icons/DocIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Document icon. Color is inherited from parent.<br/><br/>`import { MdDocIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDocIcon64 } from '@miljodirektoratet/md-react'`",
+          "Document icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdDocIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDocIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/DocSearchIcon.stories.tsx
+++ b/stories/Icons/DocSearchIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Document search icon. Color is inherited from parent.<br/><br/>`import { MdDocSearchIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDocSearchIcon64 } from '@miljodirektoratet/md-react'`",
+          "Document search icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdDocSearchIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDocSearchIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/DownloadIcon.stories.tsx
+++ b/stories/Icons/DownloadIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Download icon. Color is inherited from parent.<br/><br/>`import { MdDownloadIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDownloadIcon64 } from '@miljodirektoratet/md-react'`",
+          "Download icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdDownloadIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdDownloadIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/EditIcon.stories.tsx
+++ b/stories/Icons/EditIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Edit icon. Color is inherited from parent.<br/><br/>`import { MdEditIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdEditIcon64 } from '@miljodirektoratet/md-react'`",
+          "Edit icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdEditIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdEditIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/EnvelopeIcon.stories.tsx
+++ b/stories/Icons/EnvelopeIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Envelope icon. Color is inherited from parent.<br/><br/>`import { MdEnvelopeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdEnvelopeIcon64 } from '@miljodirektoratet/md-react'`",
+          "Envelope icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdEnvelopeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdEnvelopeIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/ExpandIcon.stories.tsx
+++ b/stories/Icons/ExpandIcon.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Expand icon. Color is inherited from parent.<br/><br/>`import { MdExpandIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdExpandIcon64 } from '@miljodirektoratet/md-react'`",
+          "Expand icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdExpandIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdExpandIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/GraphIcon.stories.tsx
+++ b/stories/Icons/GraphIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Graph icon. Color is inherited from parent.<br/><br/>`import { MdGraphIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdGraphIcon64 } from '@miljodirektoratet/md-react'`",
+          "Graph icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdGraphIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdGraphIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/HelpIcon.stories.tsx
+++ b/stories/Icons/HelpIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Help icon. Color is inherited from parent.<br/><br/>`import { MdHelpIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdHelpIcon64 } from '@miljodirektoratet/md-react'`",
+          "Help icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdHelpIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdHelpIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/HomeIcon.stories.tsx
+++ b/stories/Icons/HomeIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Home/house icon. Color is inherited from parent.<br/><br/>`import { MdHomeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdHomeIcon64 } from '@miljodirektoratet/md-react'`",
+          "Home/house icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdHomeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdHomeIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/ImageIcon.stories.tsx
+++ b/stories/Icons/ImageIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Time/clock icon. Color is inherited from parent.<br/><br/>`import { MdImageIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdImageIcon64 } from '@miljodirektoratet/md-react'`",
+          "Time/clock icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdImageIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdImageIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/InfoIcon.stories.tsx
+++ b/stories/Icons/InfoIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Info icon. Color is inherited from parent.<br/><br/>`import { MdInfoIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdInfoIcon64 } from '@miljodirektoratet/md-react'`",
+          "Info icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdInfoIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdInfoIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/MinusIcon.stories.tsx
+++ b/stories/Icons/MinusIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Minus icon. Color is inherited from parent.<br/><br/>`import { MdMinusIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdMinusIcon64 } from '@miljodirektoratet/md-react'`",
+          "Minus icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdMinusIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdMinusIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/PanIcon.stories.tsx
+++ b/stories/Icons/PanIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Pan icon. Color is inherited from parent.<br/><br/>`import { MdPanIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPanIcon64 } from '@miljodirektoratet/md-react'`",
+          "Pan icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdPanIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPanIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/PersonIcon.stories.tsx
+++ b/stories/Icons/PersonIcon.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Person icon. Color is inherited from parent.<br/><br/>`import { MdPersonIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPersonIcon64 } from '@miljodirektoratet/md-react'`",
+          "Person icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdPersonIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPersonIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/PinIcon.stories.tsx
+++ b/stories/Icons/PinIcon.stories.tsx
@@ -13,7 +13,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Pin/map pin icon. Color is inherited from parent.<br/><br/>`import { MdPinIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPinIcon64 } from '@miljodirektoratet/md-react'`<br/>`import { MdPinAltIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPinAltIcon64 } from '@miljodirektoratet/md-react'`",
+          "Pin/map pin icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdPinIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPinIcon64 } from '@miljodirektoratet/md-react'`<br/>`import { MdPinAltIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPinAltIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/PlusIcon.stories.tsx
+++ b/stories/Icons/PlusIcon.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Plus/add/expand icon. Color is inherited from parent.<br/><br/>`import { MdPlusIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPlusIcon64 } from '@miljodirektoratet/md-react'`",
+          "Plus/add/expand icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdPlusIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPlusIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/PrintIcon.stories.tsx
+++ b/stories/Icons/PrintIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Print/printer icon. Color is inherited from parent.<br/><br/>`import { MdPrintIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPrintIcon64 } from '@miljodirektoratet/md-react'`",
+          "Print/printer icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdPrintIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdPrintIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/RedirectIcon.stories.tsx
+++ b/stories/Icons/RedirectIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Redirect icon. Color is inherited from parent.<br/><br/>`import { MdRedirectIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdRedirectIcon64 } from '@miljodirektoratet/md-react'`",
+          "Redirect icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdRedirectIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdRedirectIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/SettingsIcon.stories.tsx
+++ b/stories/Icons/SettingsIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Settings icon. Color is inherited from parent.<br/><br/>`import { MdSettingsIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdSettingsIcon64 } from '@miljodirektoratet/md-react'`",
+          "Settings icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdSettingsIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdSettingsIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/SignIcon.stories.tsx
+++ b/stories/Icons/SignIcon.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Sign/Road sign icon. Color is inherited from parent.<br/><br/>`import { MdSignIcon } from '@miljodirektoratet/md-react'`",
+          "Sign/Road sign icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdSignIcon } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/SortingIcon.stories.tsx
+++ b/stories/Icons/SortingIcon.stories.tsx
@@ -13,7 +13,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Sorting icons. Color is inherited from parent.<br/><br/>`import { MdSortingIcon, MdSortingIcon64, MdSortingActiveIcon } from '@miljodirektoratet/md-react'`",
+          "Sorting icons.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdSortingIcon, MdSortingIcon64, MdSortingActiveIcon } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/SubmenuIcon.stories.tsx
+++ b/stories/Icons/SubmenuIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Submenu icon. Color is inherited from parent.<br/><br/>`import { MdSubmenuIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdSubmenuIcon64 } from '@miljodirektoratet/md-react'`",
+          "Submenu icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdSubmenuIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdSubmenuIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/TableIcon.stories.tsx
+++ b/stories/Icons/TableIcon.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Table icon. Color is inherited from parent.<br/><br/>`import { MdTableIcon } from '@miljodirektoratet/md-react'`",
+          "Table icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdTableIcon } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/TimeIcon.stories.tsx
+++ b/stories/Icons/TimeIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Time/clock icon. Color is inherited from parent.<br/><br/>`import { MdTimeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdTimeIcon64 } from '@miljodirektoratet/md-react'`",
+          "Time/clock icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdTimeIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdTimeIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/UploadIcon.stories.tsx
+++ b/stories/Icons/UploadIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Upload icon. Color is inherited from parent.<br/><br/>`import { MdUploadIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdUploadIcon64 } from '@miljodirektoratet/md-react'`",
+          "Upload icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdUploadIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdUploadIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/UserIcon.stories.tsx
+++ b/stories/Icons/UserIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "User icon. Color is inherited from parent.<br/><br/>`import { MdUserIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdUserIcon64 } from '@miljodirektoratet/md-react'`",
+          "User icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdUserIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdUserIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/WarningIcon.stories.tsx
+++ b/stories/Icons/WarningIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Warning icon. Color is inherited from parent.<br/><br/>`import { MdWarningIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdWarningIcon64 } from '@miljodirektoratet/md-react'`",
+          "Warning icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdWarningIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdWarningIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/XIcon.stories.tsx
+++ b/stories/Icons/XIcon.stories.tsx
@@ -12,7 +12,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "X/close icon. Color is inherited from parent.<br/><br/>`import { MdXIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdXIcon64 } from '@miljodirektoratet/md-react'`",
+          "X/close icon.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdXIcon } from '@miljodirektoratet/md-react'`<br/>`import { MdXIcon64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Icons/ZoomIcon.stories.tsx
+++ b/stories/Icons/ZoomIcon.stories.tsx
@@ -15,7 +15,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Zoom icons. Color is inherited from parent.<br/><br/>`import { MdZoomIcon, MdZoomIcon64, MdZoomIconPlus, MdZoomIconPlus64, MdZoomIconMinus, MdZoomIconMinus64 } from '@miljodirektoratet/md-react'`",
+          "Zoom icons.  Color can be inherited from parent, or set directly on the component. In addition to the properties presented here, the component accepts all standard attributes of a HTML SVG element.<br/><br/>`import { MdZoomIcon, MdZoomIcon64, MdZoomIconPlus, MdZoomIconPlus64, MdZoomIconMinus, MdZoomIconMinus64 } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/InfoTag.stories.tsx
+++ b/stories/InfoTag.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A component for info tag. Display icon, and hover over to display/expand info-text.<br/><br/>`import { MdInfoTag } from '@miljodirektoratet/md-react'`",
+          "A component for info tag. Display icon, and hover over to display/expand info-text. In addition to the properties presented here, the component accepts all standard attributes of a HTML Button element.<br/><br/>`import { MdInfoTag } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -79,7 +79,7 @@ export default {
       control: { type: 'text' },
     },
     mode: {
-      description: 'Set input field size-mode, possible values are "normal" and "small"',
+      description: 'Set input field width, possible values are "normal" and "small"',
       options: ['normal', 'small'],
       table: {
         defaultValue: { summary: 'normal' },

--- a/stories/Input.stories.tsx
+++ b/stories/Input.stories.tsx
@@ -26,8 +26,9 @@ export default {
         );
       },
       description: {
-        // eslint-disable-next-line quotes
-        component: "Input field used in forms.<br/><br/>`import { MdInput } from '@miljodirektoratet/md-react'`",
+        component:
+          // eslint-disable-next-line quotes
+          "Input field used in forms. In addition to the properties presented here, the component accepts all standard attributes of a HTML Input element.<br/><br/>`import { MdInput } from '@miljodirektoratet/md-react'`",
       },
     },
   },
@@ -77,8 +78,8 @@ export default {
       },
       control: { type: 'text' },
     },
-    size: {
-      description: 'Set input field size',
+    mode: {
+      description: 'Set input field size-mode, possible values are "normal" and "small"',
       options: ['normal', 'small'],
       table: {
         defaultValue: { summary: 'normal' },
@@ -254,7 +255,7 @@ export default {
         type: { summary: 'number' },
       },
     },
-    inputRef: {
+    ref: {
       type: { name: 'Ref<HTMLInputElement>' },
       // eslint-disable-next-line quotes
       description: "Ref to the inner input element, use for example to bring focus to the input when there's an error.",
@@ -293,7 +294,7 @@ Input.args = {
   value: '',
   label: 'Label',
   type: 'text',
-  size: 'normal',
+  mode: 'normal',
   disabled: false,
   readOnly: false,
   error: false,
@@ -312,7 +313,7 @@ InputWithPrefix.args = {
   value: '',
   label: 'Label',
   type: 'text',
-  size: 'normal',
+  mode: 'normal',
   disabled: false,
   readOnly: false,
   error: false,
@@ -332,7 +333,7 @@ InputWithSuffix.args = {
   value: '',
   label: 'Label',
   type: 'text',
-  size: 'normal',
+  mode: 'normal',
   disabled: false,
   readOnly: false,
   error: false,

--- a/stories/LoadingSpinner.stories.tsx
+++ b/stories/LoadingSpinner.stories.tsx
@@ -11,7 +11,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "Loading spinner component.<br/><br/>`import { MdLoadingSpinner } from '@miljodirektoratet/md-react'`",
+          "Loading spinner component. In addition to the properties presented here, the component accepts all standard attributes of a HTML Div element.<br/><br/>`import { MdLoadingSpinner } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Messages/AlertMessage.stories.tsx
+++ b/stories/Messages/AlertMessage.stories.tsx
@@ -24,7 +24,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A component for alerts. Closable/removable by default.<br/><br/>`import { MdAlertMessage } from '@miljodirektoratet/md-react'`",
+          "A component for alerts. Closable/removable by default. In addition to the properties presented here, the component accepts all standard attributes of a HTML Div element.<br/><br/>`import { MdAlertMessage } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Messages/InfoBox.stories.tsx
+++ b/stories/Messages/InfoBox.stories.tsx
@@ -22,8 +22,9 @@ export default {
         );
       },
       description: {
-        // eslint-disable-next-line quotes
-        component: "A component for info box.<br/><br/>`import { MdInfoBox } from '@miljodirektoratet/md-react'`",
+        component:
+          // eslint-disable-next-line quotes
+          "A component for info box. In addition to the properties presented here, the component accepts all standard attributes of a HTML Div element.<br/><br/>`import { MdInfoBox } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/MultiSelect.stories.tsx
+++ b/stories/MultiSelect.stories.tsx
@@ -87,8 +87,8 @@ export default {
       },
       control: { type: 'boolean' },
     },
-    size: {
-      description: 'Set size og select box',
+    mode: {
+      description: 'Set width of select box',
       options: ['large', 'medium', 'small'],
       table: {
         defaultValue: { summary: 'large' },
@@ -220,7 +220,7 @@ Multiselect.args = {
   disabled: false,
   showChips: false,
   closeOnSelect: true,
-  size: 'large',
+  mode: 'large',
   helpText: '',
   error: false,
   errorText: '',

--- a/stories/RadioButton.stories.tsx
+++ b/stories/RadioButton.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A radio button component.<br/><br/>`import { MdRadioButton } from '@miljodirektoratet/md-react'`",
+          "A radio button component. In addition to the properties presented here, the component accepts all standard attributes of a HTML Input element.<br/><br/>`import { MdRadioButton } from '@miljodirektoratet/md-react'`",
       },
     },
   },
@@ -61,12 +61,12 @@ export default {
       control: { type: 'boolean' },
     },
     id: {
-      type: { name: 'number | string' },
+      type: { name: 'string' },
       description: 'The unique id for radiogroup.',
       table: {
         defaultValue: { summary: 'uuidv4' },
         type: {
-          summary: 'number | string',
+          summary: 'string',
         },
       },
       control: { type: 'text' },
@@ -89,13 +89,13 @@ const Template = (args: MdRadioButtonProps) => {
 
   const handleChange = (e: React.ChangeEvent) => {
     const target = e.target as HTMLInputElement;
-    updateArgs({ ...args, selectedOption: target.value });
+    updateArgs({ ...args, value: target.value });
   };
 
   return (
     <MdRadioButton
       {...args}
-      selectedOption={args.selectedOption}
+      value={args.value}
       onChange={(e: React.ChangeEvent) => {
         handleChange(e);
       }}

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -83,8 +83,8 @@ export default {
       },
       control: { type: 'boolean' },
     },
-    size: {
-      description: 'Set size og select box',
+    mode: {
+      description: 'Set width of select box',
       options: ['large', 'medium', 'small'],
       table: {
         defaultValue: { summary: 'large' },
@@ -182,7 +182,7 @@ Select.args = {
   value: 'optionB',
   id: '',
   disabled: false,
-  size: 'large',
+  mode: 'large',
   helpText: '',
   error: false,
   errorText: '',

--- a/stories/Select.stories.tsx
+++ b/stories/Select.stories.tsx
@@ -64,7 +64,7 @@ export default {
       control: { type: 'text' },
     },
     id: {
-      type: { name: 'string | number' },
+      type: { name: 'string' },
       description: 'Id for the select box. If not set, uses a random uuid',
       table: {
         defaultValue: { summary: 'uuid()' },

--- a/stories/TextArea.stories.tsx
+++ b/stories/TextArea.stories.tsx
@@ -24,8 +24,9 @@ export default {
         );
       },
       description: {
-        // eslint-disable-next-line quotes
-        component: "Text area used in forms.<br/><br/>`import { MdTextArea } from '@miljodirektoratet/md-react'`",
+        component:
+          // eslint-disable-next-line quotes
+          "Text area used in forms. In addition to the properties presented here, the component accepts all standard attributes of a HTML Textarea element.<br/><br/>`import { MdTextArea } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Tile.stories.tsx
+++ b/stories/Tile.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A link styled as a horizontal tile, with optional icon (of your choice) before text.<br/><br/>`import { MdTile } from '@miljodirektoratet/md-react'`",
+          "A link/button styled as a horizontal tile, with optional icon (of your choice) before text. In addition to the properties presented here, the component accepts all standard attributes of HTML Button and Anchor element.<br/><br/>`import { MdTile } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/TileVertical.stories.tsx
+++ b/stories/TileVertical.stories.tsx
@@ -41,9 +41,9 @@ export default {
       },
       control: { type: 'text' },
     },
-    size: {
+    mode: {
       type: { name: 'string' },
-      description: 'Selected size for tile',
+      description: 'Selected width for tile',
       options: ['small', 'medium', 'large'],
       control: { type: 'inline-radio' },
       table: {
@@ -102,7 +102,7 @@ const Template = (args: Args) => {
       heading="Målinger"
       description="Oversikt over dine målestasjoner"
       href={args.href}
-      size={args.size}
+      mode={args.mode}
       disabled={args.disabled}
       preventDefault={args.preventDefault}
       icon={args.icon && <MdGraphIcon width={128} height={128} />}
@@ -113,7 +113,7 @@ const Template = (args: Args) => {
 export const TileVertical = Template.bind({});
 TileVertical.args = {
   href: '#',
-  size: 'medium',
+  mode: 'medium',
   disabled: false,
   preventDefault: true,
   icon: true,

--- a/stories/TileVertical.stories.tsx
+++ b/stories/TileVertical.stories.tsx
@@ -25,7 +25,7 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A link styled as a vertical tile, with optional icon (of your choice) before text.<br/><br/>`import { MdTileVertical } from '@miljodirektoratet/md-react'`",
+          "A link/button styled as a vertical tile, with optional icon (of your choice) before text. In addition to the properties presented here, the component accepts all standard attributes of HTML Button and Anchor element.<br/><br/>`import { MdTileVertical } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Toggle.stories.tsx
+++ b/stories/Toggle.stories.tsx
@@ -23,8 +23,9 @@ export default {
         );
       },
       description: {
-        // eslint-disable-next-line quotes
-        component: "Toggle switch.<br/><br/>`import { MdToggle } from '@miljodirektoratet/md-react'`",
+        component:
+          // eslint-disable-next-line quotes
+          "Toggle switch. In addition to the properties presented here, the component accepts all standard attributes of a HTML Input element.<br/><br/>`import { MdToggle } from '@miljodirektoratet/md-react'`",
       },
     },
   },

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ export default {
     },
   },
   argTypes: {
-    label: {
+    tooltipContent: {
       description: 'The content to display on hover',
       table: {
         type: {
@@ -40,7 +40,7 @@ export default {
       },
       control: { type: 'text' },
     },
-    ariaLabel: {
+    'aria-label': {
       description: 'The aria label for the tooltip',
       table: {
         type: {
@@ -80,7 +80,7 @@ const Template: StoryFn<typeof MdTooltip> = (args: MdTooltipProps) => {
 
 export const Tooltip = Template.bind({});
 Tooltip.args = {
-  label: 'This is some info',
+  tooltipContent: 'This is some info',
   position: 'bottom',
-  ariaLabel: 'This is some info',
+  'aria-label': 'This is some info',
 };

--- a/stories/Tooltip.stories.tsx
+++ b/stories/Tooltip.stories.tsx
@@ -26,12 +26,12 @@ export default {
       description: {
         component:
           // eslint-disable-next-line quotes
-          "A component for tooltip. Hover over to display/expand text.<br/><br/>`import { MdTooltip } from '@miljodirektoratet/md-react'`",
+          "A component for tooltip. Hover over to display/expand text. In addition to the properties presented here, the component accepts all standard attributes of a HTML Div element.<br/><br/>`import { MdTooltip } from '@miljodirektoratet/md-react'`",
       },
     },
   },
   argTypes: {
-    content: {
+    label: {
       description: 'The content to display on hover',
       table: {
         type: {
@@ -80,7 +80,7 @@ const Template: StoryFn<typeof MdTooltip> = (args: MdTooltipProps) => {
 
 export const Tooltip = Template.bind({});
 Tooltip.args = {
-  content: 'This is some info',
+  label: 'This is some info',
   position: 'bottom',
   ariaLabel: 'This is some info',
 };


### PR DESCRIPTION
# Describe your changes

Justifying use case: Need to be able to set all different kinds of aria-props on MdInput. 
aria-haspopup, aria-expanded, aria-autocomplete, aria-controls among others...

This PR extends the props of most components with the appropriate standard html attributes for the main element used within.
It also removes the use of [otherProps: string]: unknown, which previously allowed setting any prop on icons.
It also removes the use of ariaLabel as a prop, in favor of the built in aria-label prop.

This is set as a new major version because in some cases our previous custom props conflicted with one of the standard attributes and had to be renamed or got a change in type.

### Breaking changes:
-  _size_ prop replaced with _mode_ prop to control width of input component. Change affects: MdInput, MdAutocomplete, MdSelect, MdMultiSelect, MdTileVertical
- _id_ prop can now only be of type string. Change affects: MdFilterChip, MdInputChip, MdCheckbox, MdRadioButton, MdAccordion, MdCheckboxGroup, MdMultiSelect, MdRadioGroup, MdSelect
- _onChange_ prop replaced with _onSelectOption_ as callback when an option is selected. Change affects: MdAutocomplete
- _content_ prop replaced with _tooltipContent_ to set the contents of the tooltip content. Change affects: MdTooltip
- _ariaLabel_ prop replaced with standard _aria-label_ prop. Change affects: MdIconButton, MdTooltip, MdHelpButton

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
