### PR TITLE
Add tooltipClass to MdTooltip

### DIFF
--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -6,9 +6,16 @@ export interface MdTooltipProps {
   position?: 'top' | 'bottom' | 'right' | 'left';
   ariaLabel: string;
   children?: React.ReactNode;
+  tooltipClass?: string;
 }
 
-const MdTooltip: React.FC<MdTooltipProps> = ({ content, position = 'bottom', children, ariaLabel }: MdTooltipProps) => {
+const MdTooltip: React.FC<MdTooltipProps> = ({
+  content,
+  position = 'bottom',
+  children,
+  ariaLabel,
+  tooltipClass,
+}: MdTooltipProps) => {
   const [hover, setHover] = useState(false);
   const classNames = classnames('md-tooltip', {
     'md-tooltip--show': hover,
@@ -16,6 +23,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({ content, position = 'bottom', chi
     'md-tooltip--top': position === 'top',
     'md-tooltip--right': position === 'right',
     'md-tooltip--left': position === 'left',
+    tooltipClass,
   });
 
   const keydown = (event: KeyboardEvent) => {


### PR DESCRIPTION
# Describe your changes

Add property on MdTooltip to define a class name for the tooltip div, for example, a max width, rather than having to define the content with an additional styled div.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
