### PR TITLE
Remove legacy eslint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,14 +32,10 @@
     "sourceType": "module"
   },
   "plugins": ["autofix", "react-hooks"],
-  "rules": {
-    "prettier/prettier": ["error"]
-  },
   "overrides": [
     {
       "files": ["**/*.ts?(x)"],
       "rules": {
-        "prettier/prettier": ["warn"],
         "react/react-in-jsx-scope": "off",
         "spaced-comment": "warn",
         "quotes": ["warn", "single"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,13 +9,7 @@
     },
     "import/resolver": {
       "node": {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx",
-          ".md"
-        ]
+        "extensions": [".js", ".jsx", ".ts", ".tsx", ".md"]
       }
     }
   },
@@ -37,41 +31,23 @@
     "ecmaVersion": 12,
     "sourceType": "module"
   },
-  "plugins": [
-    "react",
-    "prettier",
-    "@typescript-eslint",
-    "autofix",
-    "react-hooks"
-  ],
+  "plugins": ["autofix", "react-hooks"],
   "rules": {
-    "prettier/prettier": [
-      "error"
-    ]
+    "prettier/prettier": ["error"]
   },
   "overrides": [
     {
-      "files": [
-        "**/*.ts?(x)"
-      ],
+      "files": ["**/*.ts?(x)"],
       "rules": {
-        "prettier/prettier": [
-          "warn"
-        ],
+        "prettier/prettier": ["warn"],
         "react/react-in-jsx-scope": "off",
-        "spaced-comment": "error",
-        "quotes": [
-          "error",
-          "single"
-        ],
+        "spaced-comment": "warn",
+        "quotes": ["warn", "single"],
         "no-console": "warn",
         "no-redeclare": "warn",
         "react/display-name": "error",
         "react/jsx-key": "warn",
-        "arrow-body-style": [
-          "error",
-          "always"
-        ],
+        "arrow-body-style": ["warn", "always"],
         "react/self-closing-comp": [
           "error",
           {
@@ -88,23 +64,15 @@
           }
         ],
         "@typescript-eslint/consistent-type-imports": [
-          "error",
+          "warn",
           {
             "prefer": "type-imports"
           }
         ],
         "import/order": [
-          "error",
+          "warn",
           {
-            "groups": [
-              "builtin",
-              "external",
-              "parent",
-              "sibling",
-              "index",
-              "object",
-              "type"
-            ],
+            "groups": ["builtin", "external", "parent", "sibling", "index", "object", "type"],
             "pathGroups": [
               {
                 "pattern": "@/**/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-autofix": "^1.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-storybook": "^0.6.15",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -10000,27 +9999,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.33.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
@@ -10605,12 +10583,6 @@
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -14542,18 +14514,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-error": {
@@ -24896,15 +24856,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-react": {
       "version": "7.33.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
@@ -25197,12 +25148,6 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "fast-glob": {
@@ -27962,15 +27907,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "pretty-error": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-autofix": "^1.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-storybook": "^0.6.15",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
# Describe your changes

Remove legacy eslint-prettier-plugin causing unnecessary error-squigglies and bloat.
Eslint and prettier will still work as normal.
With the legacy plugin, prettier essentially runs twice, once by eslint and once on its own.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
