### PR TITLE
Show print icon in MdFileList only for printable file types

### DIFF
--- a/packages/react/src/fileList/MdFileList.tsx
+++ b/packages/react/src/fileList/MdFileList.tsx
@@ -22,6 +22,7 @@ export interface MdFileListProps {
   allowDelete?: boolean;
   allowEdit?: boolean;
   hideIcons?: boolean;
+  printableFileTypes?: string[];
   onRemoveFile?(_file: File | FileType): void;
   onDownloadFile?(_file: File | FileType): void;
   onEditFile?(_file: File | FileType): void;
@@ -48,6 +49,7 @@ const MdFileList: React.FunctionComponent<MdFileListProps> = ({
   allowDelete = false,
   allowEdit = true,
   hideIcons = false,
+  printableFileTypes = ['pdf', 'docx'],
   onRemoveFile,
   onDownloadFile,
   onEditFile,
@@ -61,6 +63,8 @@ const MdFileList: React.FunctionComponent<MdFileListProps> = ({
       {files &&
         files.length > 0 &&
         files.map((file: FileType | File, index: number) => {
+          const fileEnding = file.name.split('.').pop();
+
           return (
             <div key={`md-filelist-file-${file.name}-${index}`} className={fileClass}>
               <div className="md-filelist__file-label">
@@ -115,7 +119,7 @@ const MdFileList: React.FunctionComponent<MdFileListProps> = ({
                   </button>
                 )}
 
-                {!hidePrint && onPrintFile && (
+                {!hidePrint && onPrintFile && fileEnding && printableFileTypes.includes(fileEnding) && (
                   <button
                     type="button"
                     aria-label="Skriv ut fil"

--- a/stories/FileList.stories.tsx
+++ b/stories/FileList.stories.tsx
@@ -87,6 +87,17 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    printableFileTypes: {
+      type: { name: 'array' },
+      description: 'Array of file types that can be printed.',
+      table: {
+        defaultValue: { summary: '["pdf"]' },
+        type: {
+          summary: 'string[]',
+        },
+      },
+      control: { type: 'array' },
+    },
     onRemoveFile: {
       type: { name: 'function' },
       description:
@@ -126,6 +137,7 @@ FileList.args = {
     { name: 'A file without url', id: 'file3', size: 2322211, type: 'application/msword' },
   ],
   hideDownload: false,
+  printableFileTypes: ['pdf'],
   hidePrint: false,
   allowDelete: true,
   allowEdit: true,


### PR DESCRIPTION
# Describe your changes

Limit which files are printable based on file ending. Allow the user of the component to modify which filetypes should be printable.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
