### PR TITLE
Add role="tooltip" to MdTooltip to avoid a11y errors with its aria-label

### DIFF
--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -48,7 +48,7 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
   };
 
   return (
-    <div aria-label={ariaLabel} {...otherProps}>
+    <div role="tooltip" aria-label={ariaLabel} {...otherProps}>
       <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>


### PR DESCRIPTION
# Describe your changes

_Replace this text with a detailed description of your changes_

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
