### PR TITLE
[Not a bug] Modal event propagation 

### DIFF
--- a/packages/react/src/utils/MdClickOutsideWrapper.tsx
+++ b/packages/react/src/utils/MdClickOutsideWrapper.tsx
@@ -26,21 +26,11 @@ const MdClickOutsideWrapper = React.forwardRef<HTMLDivElement, MdClickOutsideWra
 
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
-        const modalRef = innerRef.current;
-        const target = event.target as Node;
-        const isOutsideClick = !modalRef?.contains(target);
-
-        console.log('Target', target);
-
-        if (isOutsideClick) {
+        if (innerRef.current && !innerRef.current?.contains(event.target as Node)) {
           onClickOutside && onClickOutside(event as unknown as React.MouseEvent);
-        } else {
-          event.stopPropagation(); // Almost works, but now events don't bubble to close X etc
         }
       };
-
       document.addEventListener('click', handleClickOutside, true);
-
       return () => {
         document.removeEventListener('click', handleClickOutside, true);
       };

--- a/packages/react/src/utils/MdClickOutsideWrapper.tsx
+++ b/packages/react/src/utils/MdClickOutsideWrapper.tsx
@@ -26,11 +26,21 @@ const MdClickOutsideWrapper = React.forwardRef<HTMLDivElement, MdClickOutsideWra
 
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
-        if (innerRef.current && !innerRef.current?.contains(event.target as Node)) {
+        const modalRef = innerRef.current;
+        const target = event.target as Node;
+        const isOutsideClick = !modalRef?.contains(target);
+
+        console.log('Target', target);
+
+        if (isOutsideClick) {
           onClickOutside && onClickOutside(event as unknown as React.MouseEvent);
+        } else {
+          event.stopPropagation(); // Almost works, but now events don't bubble to close X etc
         }
       };
+
       document.addEventListener('click', handleClickOutside, true);
+
       return () => {
         document.removeEventListener('click', handleClickOutside, true);
       };

--- a/stories/Modal.stories.tsx
+++ b/stories/Modal.stories.tsx
@@ -131,7 +131,7 @@ const Template: StoryFn<typeof MdModal> = (args: Args) => {
   };
 
   return (
-    <div>
+    <div onClick={e => alert('Event bubbled up to the md stories div. :(')}>
       <MdButton
         onClick={() => {
           return toggleModal();


### PR DESCRIPTION
After some trial and error, we found out that the event propagation (naturally) only happened when the MdModal was a child element of an element with a click-handler. A real life problem happened due to this as well, even though the modal was moved in the DOM using a portal. Why this works is beyond the scope of this issue.

Similar problems can be solved by moving the <MdModal /> component outside the problematic click handler. Another solution is to wrap the Modal element itself with a handler that stops propagation upwards towards the problematic parent.

The behavior is not a bug itself with the component library. I'm therefore closing this issue.