### PR TITLE
fix: Autocomplete prefix icons not showing when component disabled and missing visual focus for AccordionItem header

### DIFF
--- a/packages/css/src/accordionitem/accordionitem.css
+++ b/packages/css/src/accordionitem/accordionitem.css
@@ -7,12 +7,6 @@
   transition: all 0.2s linear;
 }
 
-.md-accordion-item:focus-within {
-  /* outline: 2px solid var(--mdPrimaryColor80);
-  outline-offset: -2px; */
-  outline: none;
-}
-
 .md-accordion-item.md-accordion-item--rounded {
   border-radius: 4px;
 }
@@ -62,7 +56,8 @@
 }
 
 .md-accordion-item__header:focus {
-  outline: none;
+  outline: 2px solid var(--mdPrimaryColor80);
+  outline-offset: -8px;
 }
 
 .md-accordion-item__header-left {

--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -88,7 +88,7 @@
   width: 16px;
   display: flex;
   color: var(--mdPrimaryColor);
-  z-index: 0;
+  z-index: 10;
 }
 
 .md-autocomplete--small > .md-autocomplete__input__prefix {

--- a/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
+++ b/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
@@ -88,7 +88,7 @@
   width: 16px;
   display: flex;
   color: var(--mdPrimaryColor);
-  z-index: 0;
+  z-index: 10;
 }
 
 .md-multiautocomplete--small > .md-multiautocomplete__input__prefix {

--- a/stories/MultiAutocomplete.stories.tsx
+++ b/stories/MultiAutocomplete.stories.tsx
@@ -236,8 +236,8 @@ const options = [
   { value: 'optionBC', text: 'BC option' },
 ];
 
-export const Autocomplete = Template.bind({});
-Autocomplete.args = {
+export const MultiAutocomplete = Template.bind({});
+MultiAutocomplete.args = {
   label: 'Label',
   prefixIcon: <MdZoomIcon />,
   options,


### PR DESCRIPTION
# Describe your changes

Fixed a couple of CSS bugs:
- Prefix icon not showing when disabled for Autocomplete and MultiAutocomplete
- No visual focus for AccordionItem header

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
