### PR TITLE
fix: Buggy behavior with displayvalue in Autocomplete-components

### DIFF
--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -71,6 +71,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [results, setResults] = useState<MdAutocompleteOption[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
+    const [focused, setFocused] = useState(false);
 
     const autocompleteId = id && id !== '' ? id : uuidv4();
 
@@ -125,10 +126,10 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const displayedOptions = autocompleteValue
       ? results
       : defaultOptions && defaultOptions.length
-        ? defaultOptions
-        : options
-          ? options
-          : [];
+      ? defaultOptions
+      : options
+      ? options
+      : [];
     const displayedOptionsSliced =
       numberOfElementsShown == null ? displayedOptions : displayedOptions.slice(0, numberOfElementsShown);
 
@@ -193,12 +194,15 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
           <input
             autoComplete="off"
             role="combobox"
+            onBlur={() => {
+              return setFocused(false);
+            }}
             aria-expanded={open}
             aria-controls={`md-autocomplete_dropdown_${autocompleteId}`}
             id={autocompleteId}
             aria-describedby={ariaDescribedBy}
             className={inputClassNames}
-            value={open ? autocompleteValue : displayValue}
+            value={focused || open ? autocompleteValue : displayValue}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter') {
@@ -217,6 +221,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
               }
             }}
             onFocus={() => {
+              setFocused(true);
               !disabled && setOpen(true);
             }}
             type="text"

--- a/packages/react/src/formElements/MdMultiAutocomplete.tsx
+++ b/packages/react/src/formElements/MdMultiAutocomplete.tsx
@@ -68,6 +68,7 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
     const [results, setResults] = useState<MdMultiAutocompleteOption[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
+    const [focused, setFocused] = useState(false);
 
     const multiAutocompleteId = id && id !== '' ? id : uuidv4();
 
@@ -147,10 +148,10 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
     const displayedOptions = autocompleteValue
       ? results
       : defaultOptions && defaultOptions.length
-        ? defaultOptions
-        : options
-          ? options
-          : [];
+      ? defaultOptions
+      : options
+      ? options
+      : [];
     const displayedOptionsSliced =
       numberOfElementsShown == null ? displayedOptions : displayedOptions.slice(0, numberOfElementsShown);
 
@@ -221,7 +222,10 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
             id={multiAutocompleteId}
             aria-describedby={ariaDescribedBy}
             className={inputClassNames}
-            value={open ? autocompleteValue : displayValue}
+            onBlur={() => {
+              return setFocused(false);
+            }}
+            value={focused || open ? autocompleteValue : displayValue}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter') {
@@ -240,6 +244,7 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
               }
             }}
             onFocus={() => {
+              setFocused(true);
               !disabled && setOpen(true);
             }}
             type="text"


### PR DESCRIPTION
# Describe your changes
When escaping or pressing enter inside autocompletes, displayvaue was shown and user could no longer type. Fixed.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
