### PR TITLE
Correctly extend MdLink and MdTile with button/anchor-attributes

### DIFF
--- a/packages/react/src/link/MdLink.tsx
+++ b/packages/react/src/link/MdLink.tsx
@@ -1,33 +1,33 @@
 import classnames from 'classnames';
 import React, { forwardRef } from 'react';
 
-export interface MdLinkProps {
+export type MdLinkProps = {
   children?: string | React.ReactNode;
   href?: string;
   onClick?(_e: React.MouseEvent): void;
-}
+} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-const MdLink = forwardRef<
-  HTMLButtonElement | HTMLAnchorElement,
-  MdLinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ href, children, onClick, ...otherProps }, ref) => {
-  const classNames = classnames('md-link', otherProps.className);
-  return href ? (
-    <a href={href} {...otherProps} className={classNames} ref={ref as React.ForwardedRef<HTMLAnchorElement>}>
-      {children}
-    </a>
-  ) : (
-    <button
-      type="button"
-      onClick={onClick}
-      {...otherProps}
-      className={classNames}
-      ref={ref as React.ForwardedRef<HTMLButtonElement>}
-    >
-      {children}
-    </button>
-  );
-});
+const MdLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, MdLinkProps>(
+  ({ href, children, onClick, ...otherProps }, ref) => {
+    const classNames = classnames('md-link', otherProps.className);
+    return href ? (
+      <a href={href} {...otherProps} className={classNames} ref={ref as React.ForwardedRef<HTMLAnchorElement>}>
+        {children}
+      </a>
+    ) : (
+      <button
+        type="button"
+        onClick={onClick}
+        {...otherProps}
+        className={classNames}
+        ref={ref as React.ForwardedRef<HTMLButtonElement>}
+      >
+        {children}
+      </button>
+    );
+  },
+);
 
 MdLink.displayName = 'MdLink';
 export default MdLink;

--- a/packages/react/src/tiles/MdTile.tsx
+++ b/packages/react/src/tiles/MdTile.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import React from 'react';
 import MdChevronIcon from '../icons/MdChevronIcon';
 
-export interface MdTileProps {
+export type MdTileProps = {
   heading?: string;
   description?: string;
   href?: string;
@@ -10,7 +10,8 @@ export interface MdTileProps {
   icon?: React.ReactNode;
   preventDefault?: boolean;
   onClick?(_e: React.MouseEvent): void;
-}
+} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const MdTile: React.FC<MdTileProps> = ({
   heading,
@@ -21,7 +22,7 @@ const MdTile: React.FC<MdTileProps> = ({
   preventDefault = false,
   onClick,
   ...otherProps
-}: MdTileProps & React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+}: MdTileProps) => {
   const classNames = classnames(
     'md-tile',
     {

--- a/packages/react/src/tiles/MdTileVertical.tsx
+++ b/packages/react/src/tiles/MdTileVertical.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
 
-export interface MdTileVerticalProps {
+export type MdTileVerticalProps = {
   heading?: string;
   description?: string;
   /**
@@ -13,7 +13,8 @@ export interface MdTileVerticalProps {
   icon?: React.ReactNode;
   preventDefault?: boolean;
   onClick?(_e: React.MouseEvent): void;
-}
+} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   heading,
@@ -25,9 +26,7 @@ const MdTileVertical: React.FC<MdTileVerticalProps> = ({
   preventDefault = false,
   onClick,
   ...otherProps
-}: MdTileVerticalProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement> &
-  React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+}: MdTileVerticalProps) => {
   const classNames = classnames(
     'md-tile-vertical',
     {


### PR DESCRIPTION
# Describe your changes

It was not possible to add button/achor-props like aria-attributes or classname to MdLink, MdTile and MdVerticalTile. Converted their props to types and extended correctly.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
