### PR TITLE
Add multiple sizes to MdTile

### DIFF
--- a/packages/css/src/tile/README.md
+++ b/packages/css/src/tile/README.md
@@ -9,7 +9,7 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
 ## Tile horizontal
 
 ```html
-<a className="md-tile [md-tile--secondary]" href="{href}" onClick="{handleClick}">
+<a className="md-tile [md-tile--secondary, md-tile--small, md-tile--medium]" href="{href}" onClick="{handleClick}">
   <div className="md-tile__content">
     <div className="md-tile__content-icon">{icon}</div>
     <div className="md-tile__content-text">

--- a/packages/css/src/tile/tile.css
+++ b/packages/css/src/tile/tile.css
@@ -17,6 +17,16 @@
   transition: all 0.15s ease-in-out;
 }
 
+.md-tile--medium {
+  width: 424px;
+}
+
+.md-tile--small {
+  width: 320px;
+  gap: 1em;
+  padding: 16px;
+}
+
 .md-tile--secondary {
   background-color: var(--mdSecondaryColor40);
 }

--- a/packages/react/src/tiles/MdTile.tsx
+++ b/packages/react/src/tiles/MdTile.tsx
@@ -8,6 +8,7 @@ export type MdTileProps = {
   href?: string;
   theme?: string;
   disabled?: boolean;
+  mode?: 'large' | 'medium' | 'small';
   icon?: React.ReactNode;
   preventDefault?: boolean;
   onClick?(_e: React.MouseEvent): void;
@@ -19,6 +20,7 @@ const MdTile: React.FC<MdTileProps> = ({
   description,
   href,
   theme,
+  mode = 'large',
   disabled = false,
   icon = null,
   preventDefault = false,
@@ -30,6 +32,8 @@ const MdTile: React.FC<MdTileProps> = ({
     {
       'md-tile--disabled': !!disabled,
       'md-tile--secondary': theme && theme === 'secondary',
+      'md-tile--medium': mode === 'medium',
+      'md-tile--small': mode === 'small',
     },
     otherProps.className,
   );

--- a/stories/Tile.stories.tsx
+++ b/stories/Tile.stories.tsx
@@ -63,6 +63,18 @@ export default {
       },
       control: { type: 'inline-radio' },
     },
+    mode: {
+      type: { name: 'string' },
+      description: 'Selected size for tile',
+      options: ['small', 'medium', 'large'],
+      control: { type: 'inline-radio' },
+      table: {
+        defaultValue: { summary: 'large' },
+        type: {
+          summary: 'string',
+        },
+      },
+    },
     preventDefault: {
       description: 'Only use the onClick handler and prevent click from triggering href.',
       table: {
@@ -102,6 +114,7 @@ const Template = (args: Args) => {
       heading="Målinger"
       description="Oversikt over dine målestasjoner"
       href={args.href}
+      mode={args.mode}
       theme={args.theme}
       disabled={args.disabled}
       preventDefault={args.preventDefault}
@@ -114,6 +127,7 @@ export const Tile = Template.bind({});
 Tile.args = {
   href: '#',
   theme: 'primary',
+  mode: 'large',
   disabled: false,
   preventDefault: true,
   icon: true,


### PR DESCRIPTION
# Describe your changes

Add modes "medium" and "small" to MdTile following new definition in design system.
![image](https://github.com/user-attachments/assets/6328f9cb-d043-4bef-9c73-8447093dab93)
![image](https://github.com/user-attachments/assets/a0124556-5444-4b5c-a89d-823dd50e05e4)
![image](https://github.com/user-attachments/assets/957062ca-37be-4a7c-82d3-abd94cb7889b)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
