### PR TITLE
fix: aria-hidden was applied to the wrong div inside MdTooltip

### DIFF
--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -49,10 +49,12 @@ const MdTooltip: React.FC<MdTooltipProps> = ({
 
   return (
     <div role="tooltip" aria-label={ariaLabel} {...otherProps}>
-      <div aria-hidden="true" onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
+      <div onMouseLeave={setHoverFalse} onMouseEnter={setHoverTrue} className="md-tooltip__child">
         {children}
       </div>
-      <div className={classNames}>{tooltipContent}</div>
+      <div aria-hidden="true" className={classNames}>
+        {tooltipContent}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Describe your changes

Previously aria-hidden had been applied to the children the tooltip is wrapping content rather than the tooltip content itself. This caused errors in the console when the focus was trying target to the content.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
