### PR TITLE
revert: fix: (#157) 

### DIFF
--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -71,7 +71,6 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
     const [results, setResults] = useState<MdAutocompleteOption[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
-    const [focused, setFocused] = useState(false);
 
     const autocompleteId = id && id !== '' ? id : uuidv4();
 
@@ -194,15 +193,12 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
           <input
             autoComplete="off"
             role="combobox"
-            onBlur={() => {
-              return setFocused(false);
-            }}
             aria-expanded={open}
             aria-controls={`md-autocomplete_dropdown_${autocompleteId}`}
             id={autocompleteId}
             aria-describedby={ariaDescribedBy}
             className={inputClassNames}
-            value={focused || open ? autocompleteValue : displayValue}
+            value={open ? autocompleteValue : displayValue}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter') {
@@ -221,7 +217,6 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
               }
             }}
             onFocus={() => {
-              setFocused(true);
               !disabled && setOpen(true);
             }}
             type="text"

--- a/packages/react/src/formElements/MdMultiAutocomplete.tsx
+++ b/packages/react/src/formElements/MdMultiAutocomplete.tsx
@@ -68,7 +68,6 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
     const [results, setResults] = useState<MdMultiAutocompleteOption[]>([]);
     const dropdownRef = useRef<HTMLDivElement>(null);
     useDropdown(dropdownRef, open, setOpen);
-    const [focused, setFocused] = useState(false);
 
     const multiAutocompleteId = id && id !== '' ? id : uuidv4();
 
@@ -222,10 +221,7 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
             id={multiAutocompleteId}
             aria-describedby={ariaDescribedBy}
             className={inputClassNames}
-            onBlur={() => {
-              return setFocused(false);
-            }}
-            value={focused || open ? autocompleteValue : displayValue}
+            value={open ? autocompleteValue : displayValue}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter') {
@@ -244,7 +240,6 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
               }
             }}
             onFocus={() => {
-              setFocused(true);
               !disabled && setOpen(true);
             }}
             type="text"


### PR DESCRIPTION
# Describe your changes

revert: fix: When escaping or pressing enter inside autocompletes, displayvalue was shown and user could no longer type .  (#157)

New bug introduced when fixing the above. Roll back to previous bug and fix the new bug in a different PR.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
