### PR TITLE
MdFileUpload expansion

### DIFF
--- a/packages/react/src/formElements/MdFileUpload.tsx
+++ b/packages/react/src/formElements/MdFileUpload.tsx
@@ -12,12 +12,12 @@ export interface MdFileUploadProps {
   useFormData?: boolean;
   uploadButtonText?: string;
   cancelButtonText?: string;
+  uploadTexts?: [string, string];
   hideFileListIcons?: boolean;
   multiple?: boolean;
   imagesOnly?: boolean;
   automaticTrigger?: boolean;
   hideButtons?: boolean;
-  uploadTexts?: [string, string];
 }
 
 const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
@@ -26,12 +26,12 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
   useFormData = false,
   uploadButtonText = 'Last opp',
   cancelButtonText = 'Avbryt',
+  uploadTexts,
   hideFileListIcons = false,
   multiple = true,
   imagesOnly = false,
   automaticTrigger = false,
   hideButtons = false,
-  uploadTexts,
 }: MdFileUploadProps) => {
   const { files, handleDragDropEvent, clearAllFiles, createFormData, setFiles, removeFile } = useFileUpload();
 
@@ -159,13 +159,11 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
           <MdButton theme="secondary" onClick={handleCancel}>
             {cancelButtonText}
           </MdButton>
-          <MdButton onClick={handleSubmit}>
-          {/* //disabled={!files || files.length === 0} */}
+          <MdButton onClick={handleSubmit} disabled={!files || files.length === 0} >
             {uploadButtonText}
           </MdButton>
         </div>
         )}
-
     </div>
   );
 };

--- a/packages/react/src/formElements/MdFileUpload.tsx
+++ b/packages/react/src/formElements/MdFileUpload.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import MdButton from '../button/MdButton';
 import MdFileList from '../fileList/MdFileList';
 import { useFileUpload } from '../hooks/useFileUpload';
@@ -15,6 +15,9 @@ export interface MdFileUploadProps {
   hideFileListIcons?: boolean;
   multiple?: boolean;
   imagesOnly?: boolean;
+  automaticTrigger?: boolean;
+  hideButtons?: boolean;
+  uploadTexts?: [string, string];
 }
 
 const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
@@ -26,13 +29,24 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
   hideFileListIcons = false,
   multiple = true,
   imagesOnly = false,
+  automaticTrigger = false,
+  hideButtons = false,
+  uploadTexts,
 }: MdFileUploadProps) => {
   const { files, handleDragDropEvent, clearAllFiles, createFormData, setFiles, removeFile } = useFileUpload();
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleSubmit = async (e: MouseEvent) => {
-    e.preventDefault();
+  useEffect(() => {
+    if (automaticTrigger && files.length !== 0) {
+      handleSubmit();
+    }
+  }, [automaticTrigger, files]);
+
+  const handleSubmit = async (e?: MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
     if (onUpload) {
       if (useFormData) {
         const formData = createFormData();
@@ -95,7 +109,7 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
         </div>
 
         <div className="md-fileupload__droparea-content">
-          {`Dropp ${imagesOnly ? 'et bilde' : 'en fil'} her eller `}
+          {uploadTexts && uploadTexts[0] ? uploadTexts[0] : `Dropp ${imagesOnly ? 'et bilde' : 'en fil'} her eller`}
           <button
             className="md-fileupload__button"
             type="button"
@@ -103,7 +117,7 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
               return inputRef.current?.click();
             }}
           >
-            velg fra denne maskinen
+            {uploadTexts && uploadTexts[1]  ? uploadTexts[1] : 'velg fra denne maskinen'}
           </button>
           <div className="md-fileupload__droparea-content--count">
             Antall {imagesOnly ? 'bilder' : 'filer'}: {files.length} {!multiple ? '/ 1' : ''}
@@ -140,15 +154,18 @@ const MdFileUpload: React.FunctionComponent<MdFileUploadProps> = ({
           </div>
         )}
       </div>
+      {!hideButtons && (
+        <div className="md-fileupload__actions">
+          <MdButton theme="secondary" onClick={handleCancel}>
+            {cancelButtonText}
+          </MdButton>
+          <MdButton onClick={handleSubmit}>
+          {/* //disabled={!files || files.length === 0} */}
+            {uploadButtonText}
+          </MdButton>
+        </div>
+        )}
 
-      <div className="md-fileupload__actions">
-        <MdButton theme="secondary" onClick={handleCancel}>
-          {cancelButtonText}
-        </MdButton>
-        <MdButton onClick={handleSubmit} disabled={!files || files.length === 0}>
-          {uploadButtonText}
-        </MdButton>
-      </div>
     </div>
   );
 };

--- a/stories/FileUpload.stories.tsx
+++ b/stories/FileUpload.stories.tsx
@@ -95,6 +95,38 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    automaticTrigger: {
+      type: { name: 'boolean' },
+      description: 'Automatically trigger the onUpload callback whenever the filelist changes. Will not trigger when filelist becomes empty.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    hideButtons: {
+      type: { name: 'boolean' },
+      description: 'Hide upload and cancel buttons. Useful when automaticTrigger is set to true.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    uploadTexts: {
+      type: { name: 'array' },
+      description: 'Texts for upload area. Default depends on value of `imagesOnly`. Can be used to give user extra information about the upload, or change the language of the upload text.',
+      table: {
+        defaultValue: { summary: '["Dropp en fil her eller", "velg fra denne maskinen"]' },
+        type: {
+          summary: 'array',
+        },
+      },
+    },
     onUpload: {
       type: { name: 'function' },
       description:
@@ -126,4 +158,6 @@ FileUpload.args = {
   hideFileListIcons: false,
   multiple: true,
   imagesOnly: false,
+  automaticTrigger: false,
+  hideButtons: false,
 };

--- a/stories/FileUpload.stories.tsx
+++ b/stories/FileUpload.stories.tsx
@@ -73,6 +73,16 @@ export default {
       },
       control: { type: 'text' },
     },
+    uploadTexts: {
+      type: { name: 'array' },
+      description: 'Texts for upload area. Default depends on value of `imagesOnly`. Can be used to give user extra information about the upload, or change the language of the upload text.',
+      table: {
+        defaultValue: { summary: '["Dropp en fil her eller", "velg fra denne maskinen"]' },
+        type: {
+          summary: 'array',
+        },
+      },
+    },
     multiple: {
       type: { name: 'boolean' },
       description: 'Allow multiple files',
@@ -116,16 +126,6 @@ export default {
         },
       },
       control: { type: 'boolean' },
-    },
-    uploadTexts: {
-      type: { name: 'array' },
-      description: 'Texts for upload area. Default depends on value of `imagesOnly`. Can be used to give user extra information about the upload, or change the language of the upload text.',
-      table: {
-        defaultValue: { summary: '["Dropp en fil her eller", "velg fra denne maskinen"]' },
-        type: {
-          summary: 'array',
-        },
-      },
     },
     onUpload: {
       type: { name: 'function' },


### PR DESCRIPTION
# Describe your changes

Adds three new optional arguments to the MdFileUpload component
 - uploadTexts: makes it possible for developers to change static 'Dropp en fil her eller velg fra denne maskinen' text
 - automaticTrigger: boolean which makes component run onUpload every time the filelist changes (avoids users having to click 'Last opp' every time if desired)
 - hideButtons: boolean which hides the 'Avbryt' and 'Last opp' buttons. Meant to be used together with automaticTrigger.

## Checklist before requesting a review

- [ x ] I have performed a self-review and test of my code
- [ x ] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
