### PR TITLE
Fix dropdown font sizes and add "no results" for autocompletes

### DIFF
--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -144,6 +144,7 @@
   display: flex;
   align-items: center;
   font-family: 'Open sans';
+  font-size: 1em;
   border: 0;
   background-color: #fff;
   width: 100%;
@@ -175,6 +176,11 @@
   height: 12px;
   width: 12px;
   color: var(--mdPrimaryColor);
+}
+
+.md-autocomplete__dropdown-no-results {
+  padding: 1em;
+  font-style: italic;
 }
 
 /* Open state */

--- a/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
+++ b/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
@@ -162,6 +162,7 @@
   align-items: center;
   font-family: 'Open sans';
   border: 0;
+  font-size: 1em;
   background-color: #fff;
   width: 100%;
   text-align: left;
@@ -192,6 +193,11 @@
   height: 12px;
   width: 12px;
   color: var(--mdPrimaryColor);
+}
+
+.md-autocomplete__dropdown-no-results {
+  padding: 1em;
+  font-style: italic;
 }
 
 .md-multiautocomplete__chips {

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -122,6 +122,7 @@
   display: flex;
   align-items: center;
   font-family: 'Open sans';
+  font-size: 1em;
   border: 0;
   background-color: #fff;
   text-align: left;

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -124,6 +124,7 @@
   font-family: 'Open sans';
   border: 0;
   background-color: #fff;
+  font-size: 1em;
   width: 100%;
   text-align: left;
   padding: 0.9em;

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -30,6 +30,7 @@ export interface MdAutocompleteProps extends React.InputHTMLAttributes<HTMLInput
   value?: string;
   errorText?: string;
   prefixIcon?: React.ReactNode;
+  noResultsText?: string;
   dropdownHeight?: number;
   /**
    * v3.0.0: Replaces previous 'amountOfElementsShown'-prop
@@ -60,6 +61,7 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
       dropdownHeight,
       numberOfElementsShown = null,
       className,
+      noResultsText = 'Ingen resultat funnet',
       onSelectOption,
       ...otherProps
     },
@@ -265,6 +267,9 @@ const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteProps>(
                   </button>
                 );
               })}
+              {displayedOptionsSliced.length === 0 && (
+                <div className="md-autocomplete__dropdown-no-results">{noResultsText}</div>
+              )}
             </div>
           )}
         </MdClickOutsideWrapper>

--- a/packages/react/src/formElements/MdMultiAutocomplete.tsx
+++ b/packages/react/src/formElements/MdMultiAutocomplete.tsx
@@ -29,6 +29,7 @@ export interface MdMultiAutocompleteProps extends React.InputHTMLAttributes<HTML
   showChips?: boolean;
   closeOnSelect?: boolean;
   prefixIcon?: React.ReactNode;
+  noResultsText?: string;
   dropdownHeight?: number;
   /**
    * v3.0.0: Replaces previous 'amountOfElementsShown'-prop.
@@ -57,6 +58,7 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
       dropdownHeight,
       numberOfElementsShown = null,
       className,
+      noResultsText = 'Ingen resultater funnet',
       onSelectOption,
       ...otherProps
     },
@@ -289,6 +291,9 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
                   </div>
                 );
               })}
+              {displayedOptionsSliced.length === 0 && (
+                <div className="md-autocomplete__dropdown-no-results">{noResultsText}</div>
+              )}
             </div>
           )}
         </MdClickOutsideWrapper>


### PR DESCRIPTION
# Describe your changes

Update dropdown-components to follow design system specifications on font size and "no results" view in autocompletes.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
