### PR TITLE
fix: Remove ability to select checkboxes with enter

### DIFF
--- a/packages/react/src/formElements/MdMultiAutocomplete.tsx
+++ b/packages/react/src/formElements/MdMultiAutocomplete.tsx
@@ -279,11 +279,6 @@ const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAutocomple
                       disabled={!!disabled}
                       data-value={option.value}
                       data-text={option.text}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter') {
-                          return handleOptionClick(option);
-                        }
-                      }}
                       onChange={() => {
                         handleOptionClick(option);
                       }}

--- a/packages/react/src/formElements/MdMultiSelect.tsx
+++ b/packages/react/src/formElements/MdMultiSelect.tsx
@@ -228,11 +228,6 @@ const MdMultiSelect = React.forwardRef<HTMLButtonElement, MdMultiSelectProps>(
                       disabled={!!disabled}
                       data-value={option.value}
                       data-text={option.text}
-                      onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                        if (e.key === 'Enter') {
-                          return handleOptionClick(option);
-                        }
-                      }}
                       onChange={() => {
                         return handleOptionClick(option);
                       }}


### PR DESCRIPTION
# Describe your changes

Remove ability to select checkboxes with enter as they are suppesed to be checked with spacebar.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
