### PR TITLE
fix: add flex-shrink to radiobutton to avoid incorrect width in small containers

### DIFF
--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,6 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
+  /* min-width: 1.45rem; */
   height: 1.45rem;
   display: block;
   background-color: #fff;

--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,7 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
-  min-width: 1.45rem;
+  flex-shrink: 0;
   height: 1.45rem;
   display: block;
   background-color: #fff;

--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,7 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
-  /* min-width: 1.45rem; */
+  min-width: 1.45rem;
   height: 1.45rem;
   display: block;
   background-color: #fff;


### PR DESCRIPTION
# Describe your changes

Add min width to radiobutton to avoid incorrect width in small containers

<img width="211" alt="image" src="https://github.com/user-attachments/assets/d0b2487b-4ef7-45b5-86b5-09acc973c3a6">
<img width="302" alt="image" src="https://github.com/user-attachments/assets/f2e9458c-fa4b-47f9-bc47-5f34557fee60">

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
