### PR TITLE
fix: Make MdRadioButton clickable everywhere it has cursor-pointer

### DIFF
--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,6 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
+  /* min-width: 1.45rem; */
   height: 1.45rem;
   display: block;
   background-color: #fff;

--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,7 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
-  min-width: 1.45rem;
+  flex-shrink: 0;
   height: 1.45rem;
   display: block;
   background-color: #fff;

--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -30,7 +30,7 @@
 
 .md-radiobutton__check-area {
   width: 1.45rem;
-  /* min-width: 1.45rem; */
+  min-width: 1.45rem;
   height: 1.45rem;
   display: block;
   background-color: #fff;

--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -28,6 +28,11 @@
   cursor: pointer;
 }
 
+.md-radiobutton__input {
+  width: 1.45rem;
+  height: 1.45rem;
+}
+
 .md-radiobutton__check-area {
   width: 1.45rem;
   flex-shrink: 0;

--- a/packages/react/src/formElements/MdRadioButton.tsx
+++ b/packages/react/src/formElements/MdRadioButton.tsx
@@ -28,7 +28,14 @@ const MdRadioButton: React.FunctionComponent<MdRadioButtonProps> = ({
   return (
     <div className={classNames}>
       <span className="md-radiobutton__check-area">{checked && <span className="md-radiobutton__selected-dot" />}</span>
-      <input id={radioGroupId} type="radio" checked={checked} disabled={disabled} {...otherProps} />
+      <input
+        className="md-radiobutton__input"
+        id={radioGroupId}
+        type="radio"
+        checked={checked}
+        disabled={disabled}
+        {...otherProps}
+      />
       <label htmlFor={radioGroupId}>{label && label !== '' && label}</label>
     </div>
   );


### PR DESCRIPTION
# Describe your changes

When hovering MdRadioButton, the area between the label and the check_area has cursor-pointer while not being clickable. Fix by making it clickable.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
