### PR TITLE
fix: radio button click area is not covering the whole toggle button circle

### DIFF
--- a/packages/css/src/formElements/radiobutton/radiobutton.css
+++ b/packages/css/src/formElements/radiobutton/radiobutton.css
@@ -15,10 +15,12 @@
   outline: 2px solid var(--mdPrimaryColor);
   outline-offset: 2px;
 }
-
 .md-radiobutton input[type='radio'] {
   position: absolute;
   left: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
   cursor: pointer;
 }


### PR DESCRIPTION
# Describe your changes

Radio button click area is not covering the whole toggle button circle. Feedback from users stated that the radio button is annoying to use.

## Checklist before requesting a review

- [ ] I have performed a self-review and test of my code
- [ ] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
