### PR TITLE
fix: Subtract border on secondary button to make it the same size as primary/warning/tertiary

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -78,7 +78,7 @@
   background-color: #ffffff;
   border: 2px solid var(--mdPrimaryColor);
   color: var(--mdPrimaryColor);
-  padding: 0.75rem 1.5rem;
+  padding: calc(0.75rem - 2px) calc(1.5rem - 2px);
 }
 
 .md-button--small.md-button--secondary {


### PR DESCRIPTION
# Describe your changes

Different heights on the secondary button due to the border. Subtract border from padding.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
