### PR TITLE
Remove margin bottom on accordionitem

### DIFF
--- a/packages/css/src/accordionitem/accordionitem.css
+++ b/packages/css/src/accordionitem/accordionitem.css
@@ -3,7 +3,6 @@
   border: 1px solid var(--mdGreyColor60);
   color: var(--mdGreyColor);
   font-family: 'Open sans';
-  margin-bottom: 1rem;
   transition: all 0.2s linear;
 }
 


### PR DESCRIPTION
# Describe your changes

The margin bottom does not seem to be very helpful. Is this something we can remove?
I.e, I want to use the MdAccordion items inside scrollable container, and now the last item creates a weird gap at the bottom.
I can override the behavior, but it seems like a strange default.

![image](https://github.com/user-attachments/assets/a5fd4d4d-be75-47ff-9554-aaa31dbe1996)

## Checklist before requesting a review

- [ ] I have performed a self-review and test of my code
- [ ] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
