### PR TITLE
fix: Add missing MdSortingActiveIcon to gallery

### DIFF
--- a/stories/Icons/AllIconsGallery.stories.tsx
+++ b/stories/Icons/AllIconsGallery.stories.tsx
@@ -30,6 +30,7 @@ import MdPrintIcon from '../../packages/react/src/icons/MdPrintIcon';
 import MdRedirectIcon from '../../packages/react/src/icons/MdRedirectIcon';
 import MdSettingsIcon from '../../packages/react/src/icons/MdSettingsIcon';
 import MdSignIcon from '../../packages/react/src/icons/MdSignIcon';
+import MdSortingActiveIcon from '../../packages/react/src/icons/MdSortingActiveIcon';
 import MdSortingIcon from '../../packages/react/src/icons/MdSortingIcon';
 import MdSubmenuIcon from '../../packages/react/src/icons/MdSubmenuIcon';
 import MdTableIcon from '../../packages/react/src/icons/MdTableIcon';
@@ -175,6 +176,10 @@ const Template = (args: Args) => {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
         <MdSortingIcon width={args.width} height={args.height} color={args.color} className={args.className} />
         <span>MdSortingIcon</span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
+        <MdSortingActiveIcon width={args.width} height={args.height} color={args.color} className={args.className} />
+        <span>MdSortingActiveIcon</span>
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', alignItems: 'center' }}>
         <MdSubmenuIcon width={args.width} height={args.height} color={args.color} className={args.className} />


### PR DESCRIPTION
# Describe your changes

Add missing MdSortingActiveIcon to gallery in storybook.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is css-file added to `packages/css/index.css`?
