### PR TITLE
Replace remaining deprecated icons in autocomplete components

### DIFF
--- a/packages/css/src/formElements/autocomplete/autocomplete.css
+++ b/packages/css/src/formElements/autocomplete/autocomplete.css
@@ -107,7 +107,6 @@
   display: flex;
   width: 1rem;
   height: 1rem;
-  rotate: 90deg;
   color: var(--mdGreyColor);
   z-index: 0;
 }

--- a/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
+++ b/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
@@ -107,7 +107,6 @@
   display: flex;
   width: 1rem;
   height: 1rem;
-  rotate: 90deg;
   color: var(--mdGreyColor);
   z-index: 0;
 }

--- a/packages/react/src/formElements/MdAutocomplete.tsx
+++ b/packages/react/src/formElements/MdAutocomplete.tsx
@@ -5,8 +5,8 @@ import React, { useId, useRef, useState } from 'react';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 import useDropdown from '../hooks/useDropdown';
-import MdChevronIcon from '../icons/MdChevronIcon';
-import MdXIcon from '../icons/MdXIcon';
+import MdIconClose from '../icons-material/MdIconClose';
+import MdIconKeyboardArrowDown from '../icons-material/MdIconKeyboardArrowDown';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 
 /**
@@ -225,7 +225,7 @@ export const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteP
             {...otherProps}
           />
           <div aria-hidden="true" className="md-autocomplete__input-icon">
-            <MdChevronIcon transform={`rotate(${open ? '180' : '0'})`} />
+            <MdIconKeyboardArrowDown transform={`rotate(${open ? '180' : '0'})`} />
           </div>
 
           {options && options.length > 0 && (
@@ -258,7 +258,7 @@ export const MdAutocomplete = React.forwardRef<HTMLInputElement, MdAutocompleteP
                     <div className="md-autocomplete__dropdown-item-text">{option.text}</div>
                     {isSelectedOption(option) && (
                       <div className="md-autocomplete__dropdown-item-clear" title="Klikk for å fjerne valg">
-                        <MdXIcon />
+                        <MdIconClose />
                       </div>
                     )}
                   </button>

--- a/packages/react/src/formElements/MdMultiAutocomplete.tsx
+++ b/packages/react/src/formElements/MdMultiAutocomplete.tsx
@@ -6,7 +6,7 @@ import MdInputChip from '../chips/MdInputChip';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 import useDropdown from '../hooks/useDropdown';
-import MdChevronIcon from '../icons/MdChevronIcon';
+import MdIconKeyboardArrowDown from '../icons-material/MdIconKeyboardArrowDown';
 import MdClickOutsideWrapper from '../utils/MdClickOutsideWrapper';
 import MdCheckbox from './MdCheckbox';
 
@@ -251,7 +251,7 @@ export const MdMultiAutocomplete = React.forwardRef<HTMLInputElement, MdMultiAut
             <div className="md-multiautocomplete__button-hasmultiple">+{selectedOptions.length - 1}</div>
           )}
           <div aria-hidden="true" className="md-multiautocomplete__input-icon">
-            <MdChevronIcon transform={`rotate(${open ? '180' : '0'})`} />
+            <MdIconKeyboardArrowDown transform={`rotate(${open ? '180' : '0'})`} />
           </div>
 
           {options && options.length > 0 && (


### PR DESCRIPTION
# Describe your changes

This pull request replaces deprecated icons that were left behind from a previous major release.

### CSS Changes:
* Removed the `rotate: 90deg;` property from the `autocomplete.css` file.
* Removed the `rotate: 90deg;` property from the `multiautocomplete.css` file.

### React Component Changes:
* Replaced `MdChevronIcon` with `MdIconKeyboardArrowDown` in the `MdAutocomplete` component.
* Replaced `MdXIcon` with `MdIconClose` in the `MdAutocomplete` component.
* Replaced `MdChevronIcon` with `MdIconKeyboardArrowDown` in the `MdMultiAutocomplete` component.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
