### PR TITLE
266: Passing all props through MdTab

### DIFF
--- a/packages/react/src/tabs/MdTab.tsx
+++ b/packages/react/src/tabs/MdTab.tsx
@@ -6,8 +6,8 @@ export interface MdTabProps {
   children: React.ReactNode;
 }
 
-export const MdTab: React.FunctionComponent<MdTabProps> = ({ children }: MdTabProps) => {
-  return <div>{children}</div>;
+export const MdTab: React.FunctionComponent<MdTabProps> = (props: MdTabProps) => {
+  return <div {...props}></div>;
 };
 
 export default MdTab;

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -3,9 +3,10 @@
 import React, { useState } from 'react';
 import MdTabTitle from './MdTabTitle';
 import type { ReactElement, ReactNode } from 'react';
+import {MdTabProps} from "./MdTab";
 
 export interface MdTabsProps {
-  children: ReactElement[];
+  children: ReactElement<MdTabProps>[];
   initialTab?: number;
   chips?: boolean;
   chipsPrefixIcon?: ReactNode;


### PR DESCRIPTION
# Describe your changes

This might have been an issue caused by Next.js.
I changed MdTab to pass all properties to the div. That way the properties where still accessible from the child element in MdTabs. I also changed the children property for MdTabs to take props of type MdTabProps.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
