### PR TITLE
Set includesBaseElement to false in MdComboBox and MdComboBoxGrouped

### DIFF
--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -141,6 +141,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
       >
         <Ariakit.ComboboxProvider
           id={comboBoxId}
+          includesBaseElement={false}
           selectedValue={selectedValues}
           store={store}
           setSelectedValue={values => {

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -150,6 +150,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
         <Ariakit.ComboboxProvider
           id={comboBoxId}
           selectedValue={selectedValues}
+          includesBaseElement={false}
           store={store}
           setSelectedValue={values => {
             setSelectedValues(values);


### PR DESCRIPTION
# Describe your changes

Set includesBaseElement to false in MdComboBox and MdComboBoxGrouped to false to avoid unnecessary moving into the input field when navigating with arrows. The input is always active, so we don't need to move into it.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
