### PR TITLE
Expose unmountOnHide property from components using ariakit

### DIFF
--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -33,6 +33,12 @@ export interface MdComboBoxBaseProps {
   hidePrefixIcon?: boolean;
   allowReset?: boolean;
   flip?: boolean;
+  /**
+   * When `true`, the popover will be unmounted when it is hidden. This can be useful for performance reasons, but it may cause issues with animations or transitions.
+   * @default false
+   * @see https://ariakit.org/reference/combobox-popover#unmountonhide
+   */
+  unmountOnHide?: boolean;
 }
 
 export interface MdComboBoxProps extends React.InputHTMLAttributes<HTMLInputElement>, MdComboBoxBaseProps {
@@ -65,6 +71,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
       allowReset = false,
       flip = false,
       onSelectOption,
+      unmountOnHide,
       ...otherProps
     },
     ref,
@@ -228,6 +235,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
           </div>
 
           <Ariakit.ComboboxPopover
+            unmountOnHide={unmountOnHide}
             id={`${comboBoxId}_popover`}
             sameWidth
             slide={false}

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -141,6 +141,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
       >
         <Ariakit.ComboboxProvider
           id={comboBoxId}
+          includesBaseElement={false}
           selectedValue={selectedValues}
           store={store}
           setSelectedValue={values => {

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -51,6 +51,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
       flip = false,
       hideSeparatorLine = false,
       onSelectOption,
+      unmountOnHide,
       ...otherProps
     },
     ref,
@@ -239,6 +240,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
             id={`${comboBoxId}_popover`}
             sameWidth
             slide={false}
+            unmountOnHide={unmountOnHide}
             gutter={-1}
             flip={flip}
             className="md-combobox__popover"

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -150,6 +150,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
         <Ariakit.ComboboxProvider
           id={comboBoxId}
           selectedValue={selectedValues}
+          includesBaseElement={false}
           store={store}
           setSelectedValue={values => {
             setSelectedValues(values);

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -34,7 +34,7 @@ export interface MdSelectProps {
   /**
    * When `true`, the popover will be unmounted when it is hidden. This can be useful for performance reasons, but it may cause issues with animations or transitions.
    * @default false
-   * @see https://ariakit.org/reference/combobox-popover#unmountonhide
+   * @see https://ariakit.org/reference/select-popover#unmountonhide
    */
   unmountOnHide?: boolean;
   /**

--- a/packages/react/src/formElements/MdSelect.tsx
+++ b/packages/react/src/formElements/MdSelect.tsx
@@ -32,6 +32,12 @@ export interface MdSelectProps {
   dropdownHeight?: number;
   allowReset?: boolean;
   /**
+   * When `true`, the popover will be unmounted when it is hidden. This can be useful for performance reasons, but it may cause issues with animations or transitions.
+   * @default false
+   * @see https://ariakit.org/reference/combobox-popover#unmountonhide
+   */
+  unmountOnHide?: boolean;
+  /**
    * v5.0.0: onSelectOption now returns either a string or an array of strings
    */
   onSelectOption(_value: string[] | string): void;
@@ -54,6 +60,7 @@ export const MdSelect: React.FC<MdSelectProps> = React.forwardRef<HTMLButtonElem
       dropdownHeight,
       allowReset = false,
       onSelectOption,
+      unmountOnHide,
       ...otherProps
     },
     ref,
@@ -194,6 +201,7 @@ export const MdSelect: React.FC<MdSelectProps> = React.forwardRef<HTMLButtonElem
             </Ariakit.Select>
           </div>
           <Ariakit.SelectPopover
+            unmountOnHide={unmountOnHide}
             sameWidth
             slide={false}
             gutter={-1}

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -17,7 +17,7 @@ export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * When `true`, the popover will be unmounted when it is hidden. This can be useful for performance reasons, but it may cause issues with animations or transitions.
    * @default false
-   * @see https://ariakit.org/reference/combobox-popover#unmountonhide
+   * @see https://ariakit.org/reference/tooltip#unmountonhide
    */
   unmountOnHide?: boolean;
 }

--- a/packages/react/src/tooltip/MdTooltip.tsx
+++ b/packages/react/src/tooltip/MdTooltip.tsx
@@ -14,6 +14,12 @@ export interface MdTooltipProps extends React.HTMLAttributes<HTMLDivElement> {
   mode?: 'small' | 'medium' | 'large';
   anchorClassName?: string;
   tooltipClassName?: string;
+  /**
+   * When `true`, the popover will be unmounted when it is hidden. This can be useful for performance reasons, but it may cause issues with animations or transitions.
+   * @default false
+   * @see https://ariakit.org/reference/combobox-popover#unmountonhide
+   */
+  unmountOnHide?: boolean;
 }
 
 export const MdTooltip: React.FC<MdTooltipProps> = ({
@@ -23,6 +29,7 @@ export const MdTooltip: React.FC<MdTooltipProps> = ({
   timeout = 250,
   mode = 'medium',
   anchorClassName = '',
+  unmountOnHide,
   tooltipClassName = '',
   ...otherProps
 }: MdTooltipProps) => {
@@ -33,7 +40,9 @@ export const MdTooltip: React.FC<MdTooltipProps> = ({
       <TooltipAnchor aria-label={tooltipContent} className={`md-tooltip__anchor ${anchorClassName}`} {...otherProps}>
         {children}
       </TooltipAnchor>
-      <Tooltip className={classNames}>{tooltipContent}</Tooltip>
+      <Tooltip unmountOnHide={unmountOnHide} className={classNames}>
+        {tooltipContent}
+      </Tooltip>
     </TooltipProvider>
   );
 };


### PR DESCRIPTION
# Describe your changes

When adding many components using Ariakit in the same render, it can be beneficial to unmount the invisible element from the DOM to avoid excessive rerendering and performance issues. Expose this property.

## Checklist before requesting a review

- [ ] I have performed a self-review and test of my code
- [ ] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
