### PR TITLE
Tabs: Add compact variant

### DIFF
--- a/packages/css/src/tabs/README.md
+++ b/packages/css/src/tabs/README.md
@@ -7,7 +7,7 @@ Class names in brackets [] are optional-/togglable-/decorator- or state dependan
 See [Storybook](https://miljodir.github.io/md-components) for examples and more info.
 
 ```html
-<div class="md-tabs-container">
+<div class="md-tabs-container [md-tabs__compact]">
   <ul>
     <li>
       <button class="md-tabs-button [md-tabs-button--selected, md-tabs-button--disabled]">Tab 1</button>

--- a/packages/css/src/tabs/tabs.css
+++ b/packages/css/src/tabs/tabs.css
@@ -63,3 +63,47 @@
   background-color: var(--mdPrimaryColor20);
   cursor: pointer;
 }
+
+/* Compact tabs */
+.md-tabs-container.md-tabs__compact ul {
+  gap: 0;
+  flex-wrap: nowrap;
+  border-radius: 0.25rem;
+}
+
+.md-tabs-container.md-tabs__compact ul li .md-tabs-button {
+  height: 1.875rem;
+  padding: 0.25rem 1rem;
+  justify-content: center;
+  border: 0.0625rem solid var(--mdGreyColor40);
+}
+
+.md-tabs-container.md-tabs__compact ul li:first-child .md-tabs-button {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+  border-right: none;
+}
+
+.md-tabs-container.md-tabs__compact ul li:last-child .md-tabs-button {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+  border-left: none;
+}
+
+.md-tabs-container.md-tabs__compact ul li .md-tabs-button.md-tabs-button--selected {
+  background-color: var(--mdPrimaryColor80);
+  color: white;
+  border-color: var(--mdPrimaryColor80);
+  font-weight: 400;
+}
+
+
+.md-tabs-container.md-tabs__compact ul li .md-tabs-button--selected:hover:not(.md-tabs-button--disabled) {
+  background-color: var(--mdPrimaryColor);
+  color: white;
+  cursor: default;
+}
+
+.md-tabs-container.md-tabs__compact ul li .md-tabs-button::after {
+  display: none;
+}

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -9,6 +9,7 @@ export interface MdTabsProps {
   initialTab?: number;
   chips?: boolean;
   chipsPrefixIcon?: ReactNode;
+  compact?: boolean;
 }
 
 export const MdTabs: React.FunctionComponent<MdTabsProps> = ({
@@ -16,13 +17,14 @@ export const MdTabs: React.FunctionComponent<MdTabsProps> = ({
   initialTab = 0,
   chips = false,
   chipsPrefixIcon = false,
+  compact = false,
 }: MdTabsProps) => {
   const [selectedTab, setSelectedTab] = useState(initialTab);
 
   const tabs = children instanceof Array ? children : [children];
 
   return (
-    <div className="md-tabs-container">
+    <div className={`md-tabs-container${compact ? ' md-tabs__compact' : ''}`}>
       <ul>
         {tabs.map((item, index) => {
           return (

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -85,6 +85,17 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    compact: {
+      type: { name: 'boolean' },
+      description: 'Use compact mode for the tabs.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -94,6 +105,7 @@ const Template = (args: Args) => {
       initialTab={args.initialTab}
       chips={args.chips}
       chipsPrefixIcon={args.chipsPrefixIcon ? <MdIconCheck /> : null}
+      compact={args.compact}
     >
       <MdTab title="Tab 1">
         <div style={{ fontSize: '20px', marginBottom: '.5em' }}>This is the first tab</div>
@@ -121,4 +133,5 @@ Tabs.args = {
   initialTab: 0,
   chips: false,
   chipsPrefixIcon: false,
+  compact: false,
 };


### PR DESCRIPTION
# Describe your changes

Added compact variant of tabs, as per this design: https://www.figma.com/design/6BUqOC0xQZz6AggPvI2iSR/Komponenter?node-id=1842-9300&p=f&t=QLNj51axppt4SPQb-0

Note: I have not made any changes to the styling to account for chips = true, as this is not part of the design.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
