### PR TITLE
fix: Add background color to combobox input and remove global button style

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -7,6 +7,7 @@
   font-family: 'Open sans';
   font-size: 1rem;
   padding: 0.75rem 1rem;
+  font-family: inherit;
   width: fit-content;
   border: none;
 }

--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -7,7 +7,6 @@
   font-family: 'Open sans';
   font-size: 1rem;
   padding: 0.75rem 1rem;
-  font-family: inherit;
   width: fit-content;
   border: none;
 }

--- a/packages/css/src/formElements/combobox/combobox.css
+++ b/packages/css/src/formElements/combobox/combobox.css
@@ -22,6 +22,7 @@
 .md-combobox__input {
   width: 100%;
   font-size: 1rem;
+  background-color: #fff;
   line-height: 150%;
   border: 1px solid var(--mdPrimaryColor);
   padding: 0.6875rem 6rem 0.6875rem 2.5rem;

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -37,8 +37,3 @@ html {
 *:after {
   box-sizing: inherit;
 }
-
-button {
-  font-family: inherit;
-  color: #000;
-}


### PR DESCRIPTION
# Describe your changes

After upgrading to Tailwind v4, the background color became transparent on the MdCombobox. A white background color has been explicitly added for other dropdown components, but not for MdCombobox, so I also added it there.

I also noticed this global button style overriding my tailwind styles. Turns out its from md-components. I removed it. @ohp-inmeta can you verify it should be removed? Reading the message, seems like the fix should be done in the project.

![image](https://github.com/user-attachments/assets/b36b890e-9097-4933-846d-86ab6afa4bd9)
![image](https://github.com/user-attachments/assets/d0e258e0-227d-404a-a5ea-da9ac14ea608)


## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
