### PR TITLE
Add align-content to left and right icons in button styles

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -39,6 +39,7 @@
 
 .md-button__leftIcon {
   height: 1.25rem;
+  align-content: center;
   width: 1.25rem;
   flex-shrink: 0;
   margin-right: 0.5rem;
@@ -51,6 +52,7 @@
 .md-button__rightIcon {
   height: 1.25rem;
   width: 1.25rem;
+  align-content: center;
   flex-shrink: 0;
   margin-left: 0.5rem;
 }


### PR DESCRIPTION
# Describe your changes

I noticed the left/right icon in MdButton would be off center if the Icon itself is not square. Added CSS to fix it.

Before:
<img width="237" alt="Google Chrome 2025-05-11 22 03 26" src="https://github.com/user-attachments/assets/664f26ed-c845-43ff-a769-45097dd26799" />

After:
<img width="273" alt="Google Chrome 2025-05-11 22 03 33" src="https://github.com/user-attachments/assets/f4df7996-36a3-4ef9-a656-77d85719c927" />


## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
