### PR TITLE
fix: Correct outline offset of accordionitem to match Figma

### DIFF
--- a/packages/css/src/accordionitem/accordionitem.css
+++ b/packages/css/src/accordionitem/accordionitem.css
@@ -58,7 +58,6 @@
 
 .md-accordion-item__header:focus {
   outline: 2px solid var(--mdPrimaryColor80);
-  outline-offset: -8px;
 }
 
 .md-accordion-item__header-left {


### PR DESCRIPTION
# Describe your changes

fix: Correct outline offset of accordionitem to match Figma

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
