### PR TITLE
fix: only run console warning if the deprecated hook is being used

### DIFF
--- a/packages/react/src/hooks/useDropdown.ts
+++ b/packages/react/src/hooks/useDropdown.ts
@@ -6,17 +6,18 @@ const focusableHtmlElements = 'button, input, [tabindex]';
  * @deprecated This hook is deprecated and will be removed in a future release.
  * It is only being used for deprecated components.
  */
-// eslint-disable-next-line no-console
-console.warn(
-  '[DEPRECATION WARNING] useDropdown is deprecated and will be removed in a future release. ' +
-    'It is only being used for deprecated components.',
-);
 export default function useDropdown(
   ref: React.RefObject<HTMLDivElement>,
   open: boolean,
   setOpen: (_open: boolean) => void,
   elementType?: 'autocomplete' | 'select',
 ) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[DEPRECATION WARNING] useDropdown is deprecated and will be removed in a future release. ' +
+      'It is only being used for deprecated components.',
+  );
+
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
       const focusableElements = ref.current?.querySelectorAll<HTMLElement>(focusableHtmlElements);


### PR DESCRIPTION
# Describe your changes

fix: only run console warning if the deprecated hook is being used

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
