### PR TITLE
fix: modify tabindex on AccordionItem details to avoid double tabbing

### DIFF
--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -103,15 +103,9 @@ export const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
   );
 
   return (
-    <details
-      className={accordionClassNames}
-      id={accordionId}
-      name={name}
-      tabIndex={disabled ? -1 : 0}
-      aria-disabled={disabled}
-    >
+    <details className={accordionClassNames} id={accordionId} name={name} aria-disabled={disabled}>
       {/* Header */}
-      <summary className="md-accordion-item__header">
+      <summary className="md-accordion-item__header" tabIndex={disabled ? -1 : undefined} aria-disabled={disabled}>
         <div className="md-accordion-item__header-left">
           <div className="md-accordion-item__header-icon" aria-hidden="true">
             <MdIconAdd className="md-accordion-item__header-icon__open" />


### PR DESCRIPTION
# Describe your changes

fix: modify tabindex on AccordionItem details to avoid double tabbing

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
