### PR TITLE
Update button CSS selectors for better anchor tag compatibility

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -84,7 +84,7 @@
   border-color: var(--md-color-cta-primary-hover);
 }
 
-.md-button:active:enabled {
+.md-button:active:not(:disabled):not([disabled]) {
   background-color: var(--md-color-cta-primary-active);
 }
 
@@ -114,11 +114,11 @@
   padding: calc(var(--md-size-16) - 2px) calc(var(--md-size-20) - 2px);
 }
 
-.md-button--secondary:hover:enabled {
+.md-button--secondary:hover:not(:disabled):not([disabled]) {
   background-color: var(--md-color-cta-secondary-hover);
 }
 
-.md-button--secondary:focus-visible:enabled {
+.md-button--secondary:focus-visible:not(:disabled):not([disabled]) {
   background-color: var(--md-color-surface-primary);
   border-color: var(--md-color-cta-primary-focus);
   color: var(--md-color-cta-primary-focus);
@@ -126,7 +126,7 @@
   outline-offset: -6px;
 }
 
-.md-button--secondary:active:enabled {
+.md-button--secondary:active:not(:disabled):not([disabled]) {
   background-color: var(--md-color-cta-secondary-active);
   color: var(--md-color-cta-primary-hover);
   border-color: var(--md-color-cta-primary-hover);
@@ -161,23 +161,23 @@
   padding: var(--md-size-16) var(--md-size-20);
 }
 
-.md-button--tertiary:hover:enabled {
+.md-button--tertiary:hover:not(:disabled):not([disabled]) {
   text-decoration: underline;
   background-color: var(--md-color-cta-secondary-hover);
 }
 
-.md-button--tertiary:focus-visible:enabled {
+.md-button--tertiary:focus-visible:not(:disabled):not([disabled]) {
   border-color: var(--md-color-border-tertiary);
   outline: var(--md-size-2) var(--md-color-primary-80) solid;
   background-color: transparent;
   outline-offset: 0px;
 }
 
-.md-button--tertiary:focus-visible:hover:enabled {
+.md-button--tertiary:focus-visible:hover:not(:disabled):not([disabled]) {
   background-color: var(--md-color-surface-info-primary);
 }
 
-.md-button--tertiary:active:enabled {
+.md-button--tertiary:active:not(:disabled):not([disabled]) {
   background-color: var(--md-color-cta-secondary-active) !important;
   color: var(--md-color-text-visited) !important;
 }
@@ -200,17 +200,17 @@
   background-color: var(--md-color-attention-error-primary);
 }
 
-.md-button--danger:focus-visible:enabled {
+.md-button--danger:focus-visible:not(:disabled):not([disabled]) {
   background-color: var(--md-color-attention-error-primary);
   outline: var(--md-size-2) var(--md-color-text-inverted) solid;
   outline-offset: -4px;
 }
 
-.md-button--danger:hover:enabled {
+.md-button--danger:hover:not(:disabled):not([disabled]) {
   background-color: var(--md-color-attention-error-primary-hover);
 }
 
-.md-button--danger:active:enabled {
+.md-button--danger:active:not(:disabled):not([disabled]) {
   background-color: var(--md-color-attention-error-primary-active);
 }
 
@@ -230,12 +230,12 @@
   padding: calc(var(--md-size-16) - 2px) calc(var(--md-size-20) - 2px);
 }
 
-.md-button--danger-secondary:hover:enabled {
+.md-button--danger-secondary:hover:not(:disabled):not([disabled]) {
   background-color: var(--md-color-attention-error-secondary-hover);
   border-color: var(--md-color-attention-error-primary);
 }
 
-.md-button--danger-secondary:focus-visible:enabled {
+.md-button--danger-secondary:focus-visible:not(:disabled):not([disabled]) {
   background-color: var(--md-color-surface-primary);
   border-color: var(--md-color-attention-error-primary);
   color: var(--md-color-attention-error-primary);
@@ -243,7 +243,7 @@
   outline-offset: -6px;
 }
 
-.md-button--danger-secondary:active:enabled {
+.md-button--danger-secondary:active:not(:disabled):not([disabled]) {
   background-color: var(--md-color-attention-error-bg);
   color: var(--md-color-attention-error-primary-hover);
   border-color: var(--md-color-attention-error-primary-hover);


### PR DESCRIPTION
This PR replaces all usages of the :enabled pseudo-class in the button CSS with :not(:disabled):not([disabled]). The change ensures that styles for .md-button, including .md-button--secondary, apply correctly when used with anchor (<a>) tags, not just native button elements. This improves flexibility and accessibility for custom components that use anchor tags styled as buttons.

## Checklist before requesting a review

- [✅] I have performed a self-review and test of my code
- [✅] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
