### PR TITLE
Reset search value on combobox close

### DIFF
--- a/packages/css/src/formElements/combobox/combobox.css
+++ b/packages/css/src/formElements/combobox/combobox.css
@@ -54,6 +54,9 @@
   outline-offset: -2px;
   border-radius: var(--md-size-4) var(--md-size-4) var(--md-size-0) var(--md-size-0);
 }
+.md-combobox__input[data-focus-visible]:not([aria-expanded='true']) {
+  border-radius: var(--md-size-4);
+}
 
 .md-combobox__input[aria-expanded='true']::placeholder {
   opacity: 0;

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -84,6 +84,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
     const [selectedValues, setSelectedValues] = useState<string[] | string>(value);
     const [helpOpen, setHelpOpen] = useState(false);
     const [popoverOpen, setPopoverOpen] = useState(false);
+    const [pendingSearchClear, setPendingSearchClear] = useState(false);
     const store = Ariakit.useComboboxStore();
 
     useEffect(() => {
@@ -92,6 +93,22 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
         setSearchValue('');
       }
     }, [value]);
+
+    useEffect(() => {
+      if (!pendingSearchClear) return;
+
+      const checkAnimationEnd = () => {
+        const state = store.getState();
+        if (!state.animating && !state.open) {
+          setSearchValue('');
+          setPendingSearchClear(false);
+        } else {
+          requestAnimationFrame(checkAnimationEnd);
+        }
+      };
+
+      requestAnimationFrame(checkAnimationEnd);
+    }, [store, pendingSearchClear]);
 
     const matches = useMemo(() => {
       if (!searchValue && defaultOptions && defaultOptions.length > 0) {
@@ -259,7 +276,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
             aria-busy={isPending}
             style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
             onClose={() => {
-              setSearchValue('');
+              setPendingSearchClear(true);
             }}
           >
             {matches &&

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -83,6 +83,7 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
     const [searchValue, setSearchValue] = useState('');
     const [selectedValues, setSelectedValues] = useState<string[] | string>(value);
     const [helpOpen, setHelpOpen] = useState(false);
+    const [popoverOpen, setPopoverOpen] = useState(false);
     const store = Ariakit.useComboboxStore();
 
     useEffect(() => {
@@ -140,6 +141,10 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
       return false;
     }, [isMultiSelect]);
 
+    const getOpenState = () => {
+      return store.getState().open;
+    };
+
     return (
       <div
         className={`md-combobox md-combobox--${mode} ${
@@ -159,6 +164,9 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
             startTransition(() => {
               setSearchValue(val);
             });
+          }}
+          setOpen={() => {
+            setPopoverOpen(getOpenState());
           }}
         >
           {showLabel && (
@@ -224,13 +232,16 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
                 </button>
               )}
               <button
+                key={`combobox_${comboBoxId}_toggle_button_${popoverOpen}`}
                 type="button"
                 disabled={disabled}
                 className="md-combobox__toggle"
                 onClick={() => {
-                  store.setOpen(!store.getState().open);
+                  store.setOpen(!popoverOpen);
+                  setPopoverOpen(!popoverOpen);
                 }}
                 aria-label="Åpne/lukke liste"
+                tabIndex={-1}
               >
                 <MdIconKeyboardArrowDown className="md-combobox__input-arrow" aria-hidden="true" />
               </button>
@@ -247,6 +258,9 @@ const MdComboBox: React.FC<MdComboBoxProps> = React.forwardRef<HTMLInputElement,
             className="md-combobox__popover"
             aria-busy={isPending}
             style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
+            onClose={() => {
+              setSearchValue('');
+            }}
           >
             {matches &&
               matches.map(option => {

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -63,6 +63,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
     const [searchValue, setSearchValue] = useState('');
     const [selectedValues, setSelectedValues] = useState<string[] | string>(value);
     const [helpOpen, setHelpOpen] = useState(false);
+    const [popoverOpen, setPopoverOpen] = useState(false);
     const store = Ariakit.useComboboxStore();
 
     useEffect(() => {
@@ -142,6 +143,10 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
       return false;
     }, [isMultiSelect]);
 
+    const getOpenState = () => {
+      return store.getState().open;
+    };
+
     return (
       <div
         className={`md-combobox md-combobox--${mode} ${
@@ -161,6 +166,9 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
             startTransition(() => {
               setSearchValue(val);
             });
+          }}
+          setOpen={() => {
+            setPopoverOpen(getOpenState());
           }}
         >
           {showLabel && (
@@ -226,10 +234,12 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
                 </button>
               )}
               <button
+                key={`combobox_grouped_${comboBoxId}_toggle_button_${popoverOpen}`}
                 type="button"
                 className="md-combobox__toggle"
                 onClick={() => {
-                  store.setOpen(!store.getState().open);
+                  store.setOpen(!popoverOpen);
+                  setPopoverOpen(!popoverOpen);
                 }}
                 aria-label="Åpne/lukke liste"
               >
@@ -247,14 +257,20 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
             flip={flip}
             className="md-combobox__popover"
             aria-busy={isPending}
+            onClose={() => {
+              setSearchValue('');
+            }}
             style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
           >
             {matches &&
               matches.map((group, index: number) => {
                 return (
-                  <>
+                  <React.Fragment key={`combobox_group_fragment_${comboBoxId}_${group.label}_${index}`}>
                     {!hideSeparatorLine && index !== 0 && (
-                      <div className="md-combobox__group-separator">
+                      <div
+                        className="md-combobox__group-separator"
+                        key={`combobox_group_separator_${comboBoxId}_${index}`}
+                      >
                         <hr className="" />
                       </div>
                     )}
@@ -267,7 +283,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
                         {group.label}
                       </div>
                       {group.values &&
-                        group.values.map(option => {
+                        group.values.map((option, i) => {
                           let isChecked = false;
                           if (isMultiSelect) {
                             isChecked = selectedValues.includes(option.value);
@@ -276,7 +292,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
                           }
                           return (
                             <Ariakit.ComboboxItem
-                              key={`combobox_group_item_${comboBoxId}_${group.label}_${option.value}`}
+                              key={`combobox_group_item_${comboBoxId}_${group.label}_${option.value}_${i}`}
                               value={option.value}
                               focusOnHover
                               setValueOnClick={setItemCallback}
@@ -297,7 +313,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
                           );
                         })}
                     </div>
-                  </>
+                  </React.Fragment>
                 );
               })}
             {!matches.length && (

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -64,6 +64,7 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
     const [selectedValues, setSelectedValues] = useState<string[] | string>(value);
     const [helpOpen, setHelpOpen] = useState(false);
     const [popoverOpen, setPopoverOpen] = useState(false);
+    const [pendingSearchClear, setPendingSearchClear] = useState(false);
     const store = Ariakit.useComboboxStore();
 
     useEffect(() => {
@@ -72,6 +73,22 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
         setSearchValue('');
       }
     }, [value]);
+
+    useEffect(() => {
+      if (!pendingSearchClear) return;
+
+      const checkAnimationEnd = () => {
+        const state = store.getState();
+        if (!state.animating && !state.open) {
+          setSearchValue('');
+          setPendingSearchClear(false);
+        } else {
+          requestAnimationFrame(checkAnimationEnd);
+        }
+      };
+
+      requestAnimationFrame(checkAnimationEnd);
+    }, [store, pendingSearchClear]);
 
     const matches = useMemo(() => {
       if (!searchValue && defaultOptions && defaultOptions.length > 0) {
@@ -257,10 +274,10 @@ const MdComboBoxGrouped: React.FC<MdComboBoxGroupedProps> = React.forwardRef<HTM
             flip={flip}
             className="md-combobox__popover"
             aria-busy={isPending}
-            onClose={() => {
-              setSearchValue('');
-            }}
             style={{ maxHeight: dropdownHeight && `${dropdownHeight}px` }}
+            onClose={() => {
+              setPendingSearchClear(true);
+            }}
           >
             {matches &&
               matches.map((group, index: number) => {


### PR DESCRIPTION
# Describe your changes
Search is now reset when the combobox is closed.

Fixes combobox toggle and focus styling

The toggle button now correctly reflects the open/closed state of the popover, ensuring consistent user interaction. There was a problem where the popover would not close if it was opened by clicking in the searchbar and trying to close it width the arrow-button.

Also, the focus styling on the input is updated to maintain a consistent appearance, specifically addressing border radius inconsistencies when the combobox is focused but not expanded. This enhances the visual appeal and user experience.

Closes #285 

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
