### PR TITLE
Removes specific border radius from button sizes

### DIFF
--- a/packages/css/src/button/button.css
+++ b/packages/css/src/button/button.css
@@ -26,12 +26,10 @@
 
 .md-button--small {
   padding: var(--md-size-8) var(--md-size-12);
-  border-radius: var(--md-radius-sm);
 }
 
 .md-button--large {
   padding: var(--md-size-16) var(--md-size-20);
-  border-radius: var(--md-radius-lg);
 }
 
 .md-button__topIcon {


### PR DESCRIPTION
# Describe your changes

Removes the border-radius property from the small and large button size modifiers. All button size should use same border-radius, according to Figma

Closes #365 

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
