### PR TITLE
Improve TypeScript typing in icon Storybook stories

### DIFF
--- a/stories/Icons/1AllIconsGallery.stories.tsx
+++ b/stories/Icons/1AllIconsGallery.stories.tsx
@@ -47,7 +47,8 @@ import { MdIconUpload } from '../../packages/react/src/icons-material/MdIconUplo
 import { MdIconWarning } from '../../packages/react/src/icons-material/MdIconWarning';
 import { MdIconZoomIn } from '../../packages/react/src/icons-material/MdIconZoomIn';
 import { MdIconZoomOut } from '../../packages/react/src/icons-material/MdIconZoomOut';
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Gallery',
@@ -71,7 +72,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn = (args: MdIconProps) => {
   const style: React.CSSProperties = {
     display: 'flex',
     flexDirection: 'column',

--- a/stories/Icons/AccountCircle.stories.tsx
+++ b/stories/Icons/AccountCircle.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconAccountCircle } from '../../packages/react/src/icons-material/MdIconAccountCircle';
-
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Account circle',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconAccountCircle> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Add.stories.tsx
+++ b/stories/Icons/Add.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { MdIconAdd } from '../../packages/react/src/icons-material/MdIconAdd';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
-import type { Args } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Add',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconAdd> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ArrowBackward.stories.tsx
+++ b/stories/Icons/ArrowBackward.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { MdIconArrowBackward } from '../../packages/react/src/icons-material/MdIconArrowBackward';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
-import type { Args } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Arrow backward',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconArrowBackward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ArrowDownward.stories.tsx
+++ b/stories/Icons/ArrowDownward.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { MdIconArrowDownward } from '../../packages/react/src/icons-material/MdIconArrowDownward';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
-import type { Args } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Arrow downward',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconArrowDownward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ArrowForward.stories.tsx
+++ b/stories/Icons/ArrowForward.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconArrowForward } from '../../packages/react/src/icons-material/MdIconArrowForward';
-
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Arrow forward',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconArrowForward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ArrowUpward.stories.tsx
+++ b/stories/Icons/ArrowUpward.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconArrowUpward } from '../../packages/react/src/icons-material/MdIconArrowUpward';
-
-import type { Args } from '@storybook/react-webpack5';
+import type {  MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Arrow upward',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconArrowUpward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/BarChart.stories.tsx
+++ b/stories/Icons/BarChart.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconBarChart } from '../../packages/react/src/icons-material/MdIconBarChart';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Bar chart',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconBarChart> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/CalendarMonth.stories.tsx
+++ b/stories/Icons/CalendarMonth.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconCalendarMonth } from '../../packages/react/src/icons-material/MdIconCalendarMonth';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Calendar month',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconCalendarMonth> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Cancel.stories.tsx
+++ b/stories/Icons/Cancel.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconCancel } from '../../packages/react/src/icons-material/MdIconCancel';
-
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Cancel',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconCancel> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Chat.stories.tsx
+++ b/stories/Icons/Chat.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconChat } from '../../packages/react/src/icons-material/MdIconChat';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Chat',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconChat> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Check.stories.tsx
+++ b/stories/Icons/Check.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconCheck } from '../../packages/react/src/icons-material/MdIconCheck';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Check',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconCheck> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/CheckCircle.stories.tsx
+++ b/stories/Icons/CheckCircle.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconCheckCircle } from '../../packages/react/src/icons-material/MdIconCheckCircle';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Check circle',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconCheckCircle> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ChevronBackward.stories.tsx
+++ b/stories/Icons/ChevronBackward.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconChevronBackward } from '../../packages/react/src/icons-material/MdIconChevronBackward';
-
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Chevron Backward',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconChevronBackward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ChevronForward.stories.tsx
+++ b/stories/Icons/ChevronForward.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { MdIconChevronForward } from '../../packages/react/src/icons-material/MdIconChevronForward';
-
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Chevron Forward',
@@ -47,7 +47,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconChevronForward> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Close.stories.tsx
+++ b/stories/Icons/Close.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconClose } from '../../packages/react/src/icons-material/MdIconClose';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Close',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconClose> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/CollapseAll.stories.tsx
+++ b/stories/Icons/CollapseAll.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconCollapseAll } from '../../packages/react/src/icons-material/MdIconCollapseAll';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Collapse all',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconCollapseAll> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ContentCopy.stories.tsx
+++ b/stories/Icons/ContentCopy.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconContentCopy } from '../../packages/react/src/icons-material/MdIconContentCopy';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Content copy',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconContentCopy> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Delete.stories.tsx
+++ b/stories/Icons/Delete.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconDelete } from '../../packages/react/src/icons-material/MdIconDelete';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Delete',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconDelete> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Description.stories.tsx
+++ b/stories/Icons/Description.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconDescription } from '../../packages/react/src/icons-material/MdIconDescription';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Description',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconDescription> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Download.stories.tsx
+++ b/stories/Icons/Download.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconDownload } from '../../packages/react/src/icons-material/MdIconDownload';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Download',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconDownload> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Edit.stories.tsx
+++ b/stories/Icons/Edit.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconEdit } from '../../packages/react/src/icons-material/MdIconEdit';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Edit',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconEdit> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ExpandAll.stories.tsx
+++ b/stories/Icons/ExpandAll.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconExpandAll } from '../../packages/react/src/icons-material/MdIconExpandAll';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Expand all',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconExpandAll> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ExpandContent.stories.tsx
+++ b/stories/Icons/ExpandContent.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconExpandContent } from '../../packages/react/src/icons-material/MdIconExpandContent';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Expand content',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconExpandContent> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Help.stories.tsx
+++ b/stories/Icons/Help.stories.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { MdIconHelp } from '../../packages/react/src/icons-material/MdIconHelp';
 import { MdIconHelpFilled } from '../../packages/react/src/icons-material/MdIconHelpFilled';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Help',
@@ -48,7 +49,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconHelp> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Home.stories.tsx
+++ b/stories/Icons/Home.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconHome } from '../../packages/react/src/icons-material/MdIconHome';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Home',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconHome> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Image.stories.tsx
+++ b/stories/Icons/Image.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconImage } from '../../packages/react/src/icons-material/MdIconImage';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Image',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconImage> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Info.stories.tsx
+++ b/stories/Icons/Info.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconInfo } from '../../packages/react/src/icons-material/MdIconInfo';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Info',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconInfo> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/KeyboardArrowDown.stories.tsx
+++ b/stories/Icons/KeyboardArrowDown.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconKeyboardArrowDown } from '../../packages/react/src/icons-material/MdIconKeyboardArrowDown';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Keyboard Arrow Down',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconKeyboardArrowDown> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/KeyboardArrowUp.stories.tsx
+++ b/stories/Icons/KeyboardArrowUp.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconKeyboardArrowUp } from '../../packages/react/src/icons-material/MdIconKeyboardArrowUp';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Keyboard Arrow Up',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconKeyboardArrowUp> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Location.stories.tsx
+++ b/stories/Icons/Location.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconLocation } from '../../packages/react/src/icons-material/MdIconLocation';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Location',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconLocation> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Mail.stories.tsx
+++ b/stories/Icons/Mail.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconMail } from '../../packages/react/src/icons-material/MdIconMail';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Mail',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconMail> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Menu.stories.tsx
+++ b/stories/Icons/Menu.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconMenu } from '../../packages/react/src/icons-material/MdIconMenu';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Menu',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconMenu> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/More.stories.tsx
+++ b/stories/Icons/More.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconMore } from '../../packages/react/src/icons-material/MdIconMore';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/More',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconMore> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/OpenInNew.stories.tsx
+++ b/stories/Icons/OpenInNew.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconOpenInNew } from '../../packages/react/src/icons-material/MdIconOpenInNew';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Open in new',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconOpenInNew> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Person.stories.tsx
+++ b/stories/Icons/Person.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconPerson } from '../../packages/react/src/icons-material/MdIconPerson';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Person',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconPerson> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Print.stories.tsx
+++ b/stories/Icons/Print.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconPrint } from '../../packages/react/src/icons-material/MdIconPrint';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Print',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconPrint> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/QuickReference.stories.tsx
+++ b/stories/Icons/QuickReference.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconQuickReference } from '../../packages/react/src/icons-material/MdIconQuickReference';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Quick reference',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconQuickReference> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Remove.stories.tsx
+++ b/stories/Icons/Remove.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconRemove } from '../../packages/react/src/icons-material/MdIconRemove';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Remove',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconRemove> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Schedule.stories.tsx
+++ b/stories/Icons/Schedule.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconSchedule } from '../../packages/react/src/icons-material/MdIconSchedule';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Schedule',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconSchedule> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Search.stories.tsx
+++ b/stories/Icons/Search.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconSearch } from '../../packages/react/src/icons-material/MdIconSearch';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Search',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconSearch> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Settings.stories.tsx
+++ b/stories/Icons/Settings.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconSettings } from '../../packages/react/src/icons-material/MdIconSettings';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Settings',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconSettings> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Signpost.stories.tsx
+++ b/stories/Icons/Signpost.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconSignpost } from '../../packages/react/src/icons-material/MdIconSignpost';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Signpost',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconSignpost> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/SwapVert.stories.tsx
+++ b/stories/Icons/SwapVert.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MdIconSwapVert } from '../../packages/react/src/icons-material/MdIconSwapVert';
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Swap vert',
@@ -45,7 +46,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconSwapVert> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Table.stories.tsx
+++ b/stories/Icons/Table.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconTable } from '../../packages/react/src/icons-material/MdIconTable';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Table',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconTable> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Upload.stories.tsx
+++ b/stories/Icons/Upload.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconUpload } from '../../packages/react/src/icons-material/MdIconUpload';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Upload',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconUpload> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/Warning.stories.tsx
+++ b/stories/Icons/Warning.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconWarning } from '../../packages/react/src/icons-material/MdIconWarning';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Warning',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconWarning> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ZoomIn.stories.tsx
+++ b/stories/Icons/ZoomIn.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconZoomIn } from '../../packages/react/src/icons-material/MdIconZoomIn';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Zoom in',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconZoomIn> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {

--- a/stories/Icons/ZoomOut.stories.tsx
+++ b/stories/Icons/ZoomOut.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { MdIconZoomOut } from '../../packages/react/src/icons-material/MdIconZoomOut';
 
-import type { Args } from '@storybook/react-webpack5';
+import type { MdIconProps } from '../../packages/react/src/icons-material/icon.model';
+import type { StoryFn } from '@storybook/react-webpack5';
 
 export default {
   title: 'Icons/Zoom out',
@@ -47,7 +48,7 @@ export default {
   },
 };
 
-const Template = (args: Args) => {
+const Template: StoryFn<typeof MdIconZoomOut> = (args: MdIconProps) => {
   const style = { width: '32px', height: '32px', color: args.color };
 
   if (args.large) {


### PR DESCRIPTION
# Describe your changes

Discoverd error when working with new Report Icon: "storybook Property 'args' does not exist on type '(args: Args) => Element'.ts(2339) ⚠ Error (TS2339) | Property args does not exist on type ."

Replaces generic Args type with specific MdIconProps for better TypeScript intellisense and type safety in Storybook.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
