### PR TITLE
Bug fix: updated accordion styling

### DIFF
--- a/packages/css/src/accordionitem/accordionitem.css
+++ b/packages/css/src/accordionitem/accordionitem.css
@@ -1,5 +1,5 @@
 .md-accordion-item {
-  background-color: var(--md-color-surface-secondary);
+  background-color: var(--md-color-surface-primary);
   border: 1px solid var(--md-color-border-primary);
   color: var(--md-color-text-primary);
   font-family: 'Open sans';


### PR DESCRIPTION
# Describe your changes

Wrong primary state background color

Before:

https://github.com/user-attachments/assets/8ca4058d-2d25-4445-b989-1b03e45734e4

Now: 
<img width="1050" height="1100" alt="image" src="https://github.com/user-attachments/assets/fceb3630-4896-4165-a2d6-bdddcab46f34" />


## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
