### PR TITLE
fix: focus styles should use :focus-within instead of :focus-visible-within

### DIFF
--- a/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
+++ b/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
@@ -62,7 +62,7 @@
 }
 
 .md-multiautocomplete__input:focus-visible,
-.md-multiautocomplete__input:focus-visible-within {
+.md-multiautocomplete__input:focus-within {
   outline: none;
 }
 

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -51,20 +51,20 @@
 }
 
 .md-multiselect__button:focus-visible,
-.md-multiselect__button:focus-visible-within {
+.md-multiselect__button:focus-within {
   outline: none;
 }
 .md-multiselect:not(.md-multiselect--disabled)
   .md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-visible,
 .md-multiselect:not(.md-multiselect--disabled)
-  .md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-visible-within {
+  .md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-within {
   padding: calc(0.75rem - 1px);
   border: 2px solid var(--mdPrimaryColor80);
 }
 
 .md-multiselect:not(.md-multiselect--disabled) .md-multiselect__button:not(.md-multiselect__button--open):focus-visible,
 .md-multiselect:not(.md-multiselect--disabled)
-  .md-multiselect__button:not(.md-multiselect__button--open):focus-visible-within {
+  .md-multiselect__button:not(.md-multiselect__button--open):focus-within {
   padding: calc(1rem - 1px);
   border: 2px solid var(--mdPrimaryColor80);
 }
@@ -161,7 +161,7 @@
 
 .md-multiselect__dropdown-item:hover,
 .md-multiselect__dropdown-item:focus-visible,
-.md-multiselect__dropdown-item:focus-visible-within {
+.md-multiselect__dropdown-item:focus-within {
   outline: none;
   background-color: var(--mdPrimaryColor20);
   transition: background-color 0.15s ease-in-out;
@@ -169,13 +169,13 @@
 
 .md-multiselect__dropdown-item:hover .md-checkbox__label,
 .md-multiselect__dropdown-item:focus-visible .md-checkbox__label,
-.md-multiselect__dropdown-item:focus-visible-within .md-checkbox__label {
+.md-multiselect__dropdown-item:focus-within .md-checkbox__label {
   outline: none;
 }
 
 .md-multiselect__dropdown-item:hover .md-checkbox .md-checkbox__label::before,
 .md-multiselect__dropdown-item:focus-visible .md-checkbox .md-checkbox__label::before,
-.md-multiselect__dropdown-item:focus-visible-within .md-checkbox .md-checkbox__label::before {
+.md-multiselect__dropdown-item:focus-within .md-checkbox .md-checkbox__label::before {
   background-color: #fff;
 }
 
@@ -233,13 +233,13 @@
 }
 
 .md-multiselect__button:not(.md-multiselect__button--open):focus-visible,
-.md-multiselect__button:not(.md-multiselect__button--open):focus-visible-within {
+.md-multiselect__button:not(.md-multiselect__button--open):focus-within {
   padding: calc(1rem - 1px);
   border: 2px solid var(--mdPrimaryColor80);
 }
 
 .md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-visible,
-.md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-visible-within {
+.md-multiselect__button.md-multiselect--small:not(.md-multiselect__button--open):focus-within {
   padding: calc(0.75rem - 1px);
   border: 2px solid var(--mdPrimaryColor80);
 }

--- a/packages/css/src/toggle/toggle.css
+++ b/packages/css/src/toggle/toggle.css
@@ -2,7 +2,7 @@
   display: flex;
 }
 
-.md-toggle__wrapper:focus-visible-within,
+.md-toggle__wrapper:focus-within,
 .md-toggle__wrapper:focus-visible {
   outline: none;
 }
@@ -25,7 +25,7 @@
   cursor: pointer;
 }
 
-.md-toggle__wrapper:focus-visible-within .md-toggle__label-wrapper {
+.md-toggle__wrapper:focus-within .md-toggle__label-wrapper {
   outline: 2px solid var(--md-color-cta-primary-focus);
   outline-offset: var(--md-size-4);
 }


### PR DESCRIPTION
# Describe your changes

I was getting errors in my project:
` ^-- 'focus-visible-within' is not recognized as a valid pseudo-class. Did you mean '::focus-visible-within' (pseudo-element) or is this a typo?`

Focus styles did not apply correctly in storybook either. Fixed.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
