### PR TITLE
fix: Make form field labels bold to match Figma designs (#387)

### DIFF
--- a/packages/css/src/formElements/input/input.css
+++ b/packages/css/src/formElements/input/input.css
@@ -73,7 +73,10 @@
 .md-input__label {
   display: flex;
   align-items: flex-end;
-  font-weight: var(--md-typography-font-weight-medium);
+}
+
+.md-input__label label {
+  font-weight: var(--md-typography-weight-medium);
 }
 
 .md-input__label > * + * {

--- a/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
+++ b/packages/css/src/formElements/multiautocomplete/multiautocomplete.css
@@ -19,8 +19,11 @@
 .md-multiautocomplete__label {
   display: flex;
   align-items: flex-end;
-  font-weight: 600;
   padding-bottom: 0.5rem;
+}
+
+.md-multiautocomplete__label label {
+  font-weight: var(--md-typography-weight-medium);
 }
 
 .md-multiautocomplete__label > * + * {

--- a/packages/css/src/formElements/multiselect/multiselect.css
+++ b/packages/css/src/formElements/multiselect/multiselect.css
@@ -14,7 +14,10 @@
 .md-multiselect__label {
   display: flex;
   align-items: flex-end;
-  font-weight: 600;
+}
+
+.md-multiselect__label label {
+  font-weight: var(--md-typography-weight-medium);
 }
 
 .md-multiselect__label-wrapper {

--- a/packages/css/src/formElements/select/select.css
+++ b/packages/css/src/formElements/select/select.css
@@ -12,8 +12,6 @@
   display: flex;
   align-items: center;
   gap: var(--md-size-8);
-}
-.md-select__label label {
   font-weight: var(--md-typography-weight-medium);
 }
 

--- a/packages/css/src/formElements/textarea/textarea.css
+++ b/packages/css/src/formElements/textarea/textarea.css
@@ -50,7 +50,10 @@
 .md-textarea__label {
   display: flex;
   align-items: flex-end;
-  font-weight: var(--md-typography-font-weight-medium);
+}
+
+.md-textarea__label label {
+  font-weight: var(--md-typography-weight-medium);
 }
 
 .md-textarea__label > * + * {


### PR DESCRIPTION
# Describe your changes

Made form field labels (Input, TextArea, Select, MultiSelect, MultiAutocomplete) consistently bold by applying font-weight: 600 design token to match Figma designs.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
