### PR TITLE
Fixes typo in color token name

### DIFF
--- a/stories/Colors/Tokens.mdx
+++ b/stories/Colors/Tokens.mdx
@@ -73,7 +73,7 @@ These tokens use variables defined in the [Colors section](/docs/introduction-co
 <Token token="--md-color-attention-warning-surface" variable="var(--md-color-attention-warning-1)" />
 <Token token="--md-color-attention-warning-surface-tinted" variable="var(--md-color-attention-warning-2)" />
 <Token token="--md-color-attention-warning-surface-hover" variable="var(--md-color-attention-warning-3)" />
-<Token token="--md-color-attention-warning-surface-acive" variable="var(--md-color-attention-warning-4)" />
+<Token token="--md-color-attention-warning-surface-active" variable="var(--md-color-attention-warning-4)" />
 <Token token="--md-color-attention-warning-border" variable="var(--md-color-attention-warning-5)" />
 
 ##### Success


### PR DESCRIPTION
# Describe your changes

Corrects a typo in the `--md-color-attention-warning-surface-acive` token name, changing it to `--md-color-attention-warning-surface-active`.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
