### PR TITLE
fix: update focus style for toggle wrapper to use :has(:focus-visible)

### DIFF
--- a/packages/css/src/toggle/toggle.css
+++ b/packages/css/src/toggle/toggle.css
@@ -25,7 +25,7 @@
   cursor: pointer;
 }
 
-.md-toggle__wrapper:focus-within .md-toggle__label-wrapper {
+.md-toggle__wrapper:has(:focus-visible) .md-toggle__label-wrapper {
   outline: 2px solid var(--md-color-cta-primary-focus);
   outline-offset: var(--md-size-4);
 }


### PR DESCRIPTION
# Describe your changes

fix: update focus style for toggle wrapper to use :has(:focus-visible)

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If new component: Is story for component created in `stories`-folder?
- [ ] If new component: Is README-file for CSS documentation created and added to the story?
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?
