### PR TITLE
Adjusts combobox input padding for reset button

### DIFF
--- a/packages/css/src/formElements/combobox/combobox.css
+++ b/packages/css/src/formElements/combobox/combobox.css
@@ -26,7 +26,7 @@
   line-height: var(--md-typography-line-height-medium);
   border: 1px solid var(--md-color-border-primary);
   border-radius: var(--md-size-4);
-  padding: 0.6875rem 6rem 0.6875rem 2.5rem;
+  padding: 0.6875rem 5rem 0.6875rem 2.5rem;
 }
 .md-combobox--large .md-combobox__input {
   padding: 0.9375rem 4rem 0.9375rem 2.5rem;
@@ -39,6 +39,13 @@
 .md-combobox--small .md-combobox__input--no-prefix-icon {
   padding-left: var(--md-size-12);
 }
+
+.md-combobox__input--no-reset-button,
+.md-combobox--large .md-combobox__input--no-reset-button,
+.md-combobox--small .md-combobox__input--no-reset-button {
+  padding-right: 3rem;
+}
+
 .md-combobox__input::placeholder {
   color: var(--md-color-border-primary);
   font-size: var(--md-typography-size-16);

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -254,7 +254,7 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
             <Ariakit.Combobox
               ref={ref}
               placeholder={displayValue}
-              className={`md-combobox__input ${hidePrefixIcon && 'md-combobox__input--no-prefix-icon'}`}
+              className={`md-combobox__input ${hidePrefixIcon && 'md-combobox__input--no-prefix-icon'} ${!allowReset && 'md-combobox__input--no-reset-button'}`}
               disabled={disabled}
               aria-describedby={ariaDescribedBy}
               value={searchValue}

--- a/packages/react/src/formElements/MdComboBoxGrouped.tsx
+++ b/packages/react/src/formElements/MdComboBoxGrouped.tsx
@@ -258,7 +258,7 @@ const MdComboBoxGrouped = React.forwardRef<HTMLInputElement, MdComboBoxGroupedPr
             <Ariakit.Combobox
               ref={ref}
               placeholder={displayValue}
-              className={`md-combobox__input ${hidePrefixIcon && 'md-combobox__input--no-prefix-icon'}`}
+              className={`md-combobox__input ${hidePrefixIcon && 'md-combobox__input--no-prefix-icon'} ${!allowReset && 'md-combobox__input--no-reset-button'}`}
               disabled={disabled}
               aria-describedby={ariaDescribedBy}
               value={searchValue}


### PR DESCRIPTION
# Describe your changes

Updates the default right padding for combobox inputs. Introduces a CSS modifier class to reduce right padding when the reset button is not allowed, preventing text truncation or overlap. This class is conditionally applied in React `MdComboBox` and `MdComboBoxGrouped` components based on the `allowReset` prop.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If applicable: Is story created/updated in `stories`-folder?
- [ ] If applicable: Is README-file for CSS documentation created/updated?
- [ ] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?