### PR TITLE
Added indeterminate state to MdCheckbox

### DIFF
--- a/packages/css/src/formElements/checkbox/checkbox.css
+++ b/packages/css/src/formElements/checkbox/checkbox.css
@@ -45,6 +45,13 @@
   background-size: 1.125rem;
 }
 
+.md-checkbox__input:indeterminate + .md-checkbox__label::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 13 3'%3E%3Crect x='1' y='0.5' width='11' height='2' rx='0.5' fill='%2300615c'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 0.75rem;
+}
+
 .md-checkbox--disabled .md-checkbox__label::before,
 .md-checkbox--disabled .md-checkbox__input:focus-visible + .md-checkbox__label::before,
 .md-checkbox--disabled:hover .md-checkbox__label::before {

--- a/packages/react/src/formElements/MdCheckbox.tsx
+++ b/packages/react/src/formElements/MdCheckbox.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import classnames from 'classnames';
-import React, { useId } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 
 export interface MdCheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: React.ReactNode;
+  indeterminate?: boolean;
 }
 
 export const MdCheckbox: React.FunctionComponent<MdCheckboxProps> = ({
@@ -12,6 +13,7 @@ export const MdCheckbox: React.FunctionComponent<MdCheckboxProps> = ({
   id,
   disabled,
   className = '',
+  indeterminate,
   ...otherProps
 }: MdCheckboxProps) => {
   const classNames = classnames(
@@ -23,14 +25,24 @@ export const MdCheckbox: React.FunctionComponent<MdCheckboxProps> = ({
   );
   const uuid = useId();
   const checkboxId = id || uuid;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = !!indeterminate && !otherProps.checked;
+    }
+  }, [indeterminate, otherProps.checked]);
+
   return (
     <div className={classNames}>
       <input
+        ref={inputRef}
         id={checkboxId || undefined}
         disabled={disabled}
         className="md-checkbox__input"
         type="checkbox"
-        aria-checked={otherProps.checked || false}
+        aria-checked={indeterminate && !otherProps.checked ? 'mixed' : (otherProps.checked || false)}
         {...otherProps}
       />
       <label className="md-checkbox__label" htmlFor={checkboxId || undefined}>

--- a/packages/react/src/formElements/tests/MdCheckbox.test.tsx
+++ b/packages/react/src/formElements/tests/MdCheckbox.test.tsx
@@ -42,6 +42,24 @@ describe('MdCheckbox', () => {
       const { container } = render(<MdCheckbox disabled />);
       expect(container.querySelector('.md-checkbox--disabled')).toBeInTheDocument();
     });
+
+    it('sets indeterminate state on the input element', () => {
+      render(<MdCheckbox indeterminate />);
+      const checkbox = screen.getByRole('checkbox');
+      expect((checkbox as HTMLInputElement).indeterminate).toBe(true);
+    });
+
+    it('has aria-checked mixed when indeterminate', () => {
+      render(<MdCheckbox indeterminate />);
+      expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'mixed');
+    });
+
+    it('is not indeterminate when checked', () => {
+      render(<MdCheckbox indeterminate checked onChange={() => {}} />);
+      const checkbox = screen.getByRole('checkbox');
+      expect((checkbox as HTMLInputElement).indeterminate).toBe(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
   });
 
   describe('interactions', () => {

--- a/stories/Checkbox.stories.tsx
+++ b/stories/Checkbox.stories.tsx
@@ -70,6 +70,16 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    indeterminate: {
+      description: 'Set the checkbox to an indeterminate state',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
     onChange: {
       description: 'Callback for controlling checked state',
       table: {


### PR DESCRIPTION
# Describe your changes

Added indeterminate state to MdCheckbox. When the box is unchecked it can be displayed as indeterminate. This is useful when the checkbox represent selection of a group of sub-selections.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [x] If applicable: Is story created/updated in `stories`-folder?
- [x] If applicable: Is README-file for CSS documentation created/updated?
- [x] If applicable: Are unit tests created/updated for the component?
- [x] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [x] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [x] If new component: Is CSS-file added to `packages/css/index.css`?