### PR TITLE
Adds `supportText` prop to ComboBox

### DIFF
--- a/packages/css/src/formElements/combobox/README.md
+++ b/packages/css/src/formElements/combobox/README.md
@@ -57,7 +57,10 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
     <div class="md-combobox__checkbox-item md-combobox__checkbox-item--no-result">No results found</div>
   </Ariakit.ComboboxPopover>
 
-  <!-- Error text -->
+  <!-- Support text (optional, rendered below the input when supportText prop is provided) -->
+  <div class="md-combobox__support">{supportText}</div>
+
+  <!-- Error text (rendered below support text when the component has an error) -->
   <div class="md-combobox__error">{errorText}</div>
 </div>
 ```
@@ -72,3 +75,5 @@ The MdComboBox component uses Ariakit's ComboBox component which handles numerou
 - Screen reader announcements
 
 When implementing this outside of React, you'll need to handle these accessibility concerns manually. The library automatically manages attributes like `aria-activedescendant`, `aria-controls`, `aria-expanded`, etc.
+
+The `.md-combobox__support` element provides supplementary descriptive text below the input. When used alongside `.md-combobox__error`, the support text appears above the error message. Ensure the support text element is associated with the input using `aria-describedby` so screen readers can announce it.

--- a/packages/css/src/formElements/combobox/README.md
+++ b/packages/css/src/formElements/combobox/README.md
@@ -57,7 +57,7 @@ See [Storybook](https://miljodir.github.io/md-components) for examples and more 
     <div class="md-combobox__checkbox-item md-combobox__checkbox-item--no-result">No results found</div>
   </Ariakit.ComboboxPopover>
 
-  <!-- Support text (optional, rendered below the input when supportText prop is provided) -->
+  <!-- Support text (optional, rendered below the input when supplementary descriptive text is needed) -->
   <div class="md-combobox__support">{supportText}</div>
 
   <!-- Error text (rendered below support text when the component has an error) -->

--- a/packages/css/src/formElements/combobox/combobox.css
+++ b/packages/css/src/formElements/combobox/combobox.css
@@ -229,6 +229,13 @@
   transition: max-height 0.5s ease-in;
 }
 
+/* Support text */
+.md-combobox__support {
+  margin-top: var(--md-size-8);
+  color: var(--md-color-text-primary);
+  font-size: var(--md-typography-size-14);
+}
+
 /* Error */
 .md-combobox__error {
   margin-top: var(--md-size-8);

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -29,6 +29,7 @@ export interface MdComboBoxBaseProps {
   errorText?: string;
   placeholder?: string;
   helpText?: string;
+  supportText?: string;
   numberOfElementsShown?: number;
   isSearching?: boolean;
   mode?: 'large' | 'medium' | 'small';
@@ -67,6 +68,7 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
       numberOfElementsShown,
       mode = 'medium',
       helpText,
+      supportText,
       error = false,
       errorText,
       noResultsText = 'Ingen treff',
@@ -338,6 +340,12 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
             </div>
           </Ariakit.ComboboxPopover>
         </Ariakit.ComboboxProvider>
+
+        {supportText && supportText !== '' && (
+          <div id={`md-combobox_support_${comboBoxId}`} className="md-combobox__support">
+            {supportText}
+          </div>
+        )}
 
         {error && errorText && errorText !== '' && (
           <div id={`md-combobox_error_${comboBoxId}`} className="md-combobox__error">

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -185,8 +185,17 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
       displayValue = getValueById(selectedValues as string);
     }
 
-    let ariaDescribedBy = helpText && helpText !== '' ? `md-combobox_help-text_${comboBoxId}` : undefined;
-    ariaDescribedBy = error && errorText && errorText !== '' ? `md-combobox_error_${comboBoxId}` : ariaDescribedBy;
+    const ariaDescribedByIds: string[] = [];
+    if (helpText && helpText !== '') {
+      ariaDescribedByIds.push(`md-combobox_help-text_${comboBoxId}`);
+    }
+    if (supportText && supportText !== '') {
+      ariaDescribedByIds.push(`md-combobox_support_${comboBoxId}`);
+    }
+    if (error && errorText && errorText !== '') {
+      ariaDescribedByIds.push(`md-combobox_error_${comboBoxId}`);
+    }
+    const ariaDescribedBy = ariaDescribedByIds.length > 0 ? ariaDescribedByIds.join(' ') : undefined;
 
     const showLabel = (label && label !== '') || (helpText && helpText !== '');
 

--- a/packages/react/src/formElements/tests/MdComboBox.test.tsx
+++ b/packages/react/src/formElements/tests/MdComboBox.test.tsx
@@ -152,7 +152,7 @@ describe('MdComboBox', () => {
       expect(input).toHaveAttribute('aria-describedby', supportText.getAttribute('id'));
     });
 
-    it('includes help, support and error ids in aria-describedby', () => {
+    it('includes help, support, and error ids in aria-describedby', () => {
       render(
         <MdComboBox
           options={mockOptions}

--- a/packages/react/src/formElements/tests/MdComboBox.test.tsx
+++ b/packages/react/src/formElements/tests/MdComboBox.test.tsx
@@ -143,6 +143,37 @@ describe('MdComboBox', () => {
     });
   });
 
+  describe('accessibility', () => {
+    it('includes support text id in aria-describedby', () => {
+      render(<MdComboBox options={mockOptions} value="" onSelectOption={() => {}} supportText="Helpful context" />);
+
+      const input = screen.getByRole('combobox');
+      const supportText = screen.getByText('Helpful context');
+      expect(input).toHaveAttribute('aria-describedby', supportText.getAttribute('id'));
+    });
+
+    it('includes help, support and error ids in aria-describedby', () => {
+      render(
+        <MdComboBox
+          options={mockOptions}
+          value=""
+          onSelectOption={() => {}}
+          helpText="Help text"
+          supportText="Support text"
+          error
+          errorText="Error text"
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      const describedBy = input.getAttribute('aria-describedby');
+
+      expect(describedBy).toContain('md-combobox_help-text_');
+      expect(describedBy).toContain('md-combobox_support_');
+      expect(describedBy).toContain('md-combobox_error_');
+    });
+  });
+
   describe('reset functionality', () => {
     it('shows reset button when allowReset is true and value is selected', () => {
       const { container } = render(

--- a/stories/ComboBox.stories.tsx
+++ b/stories/ComboBox.stories.tsx
@@ -127,6 +127,17 @@ export default {
       },
       control: { type: 'text' },
     },
+    supportText: {
+      type: { name: 'string' },
+      description: 'Support text for the combobox',
+      table: {
+        defaultValue: { summary: 'null' },
+        type: {
+          summary: 'string',
+        },
+      },
+      control: { type: 'text' },
+    },
     error: {
       type: { name: 'boolean' },
       description: 'Whether the combobox is in an error state',
@@ -251,6 +262,7 @@ Multi.args = {
   disabled: false,
   mode: 'medium',
   helpText: 'This is a help text',
+  supportText: 'This is a support text',
   prefixIcon: <MdIconSearch />,
   errorText: '',
   error: false,
@@ -276,6 +288,7 @@ Single.args = {
   disabled: false,
   mode: 'medium',
   helpText: 'This is a help text',
+  supportText: 'This is a support text',
   prefixIcon: <MdIconCalendarMonth />,
   errorText: 'This is an example of an error text',
   error: true,


### PR DESCRIPTION
# Describe your changes

Provides a dedicated slot for displaying supplementary descriptive text below the combobox. Enhances user guidance by offering an alternative to help or error messages. Includes styling and Storybook examples.

The combobox CSS README has been updated to include `.md-combobox__support` in the HTML structure example and accessibility notes, documenting where and when support text should be rendered.

Addressed review feedback by wiring support text into the combobox input `aria-describedby` (space-separated together with existing help/error ids when present), so screen readers announce the support text correctly. Added/updated unit tests for this `aria-describedby` behavior.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If applicable: Is story created/updated in `stories`-folder?
- [x] If applicable: Is README-file for CSS documentation created/updated?
- [x] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?