### PR TITLE
Adjusts error surface active token and documentation

### DIFF
--- a/packages/css/src/tokens/tokens.css
+++ b/packages/css/src/tokens/tokens.css
@@ -31,6 +31,7 @@
   --md-color-attention-error-surface: var(--md-color-attention-error-1);
   --md-color-attention-error-surface-tinted: var(--md-color-attention-error-2);
   --md-color-attention-error-surface-hover: var(--md-color-attention-error-3);
+  --md-color-error-surface-active: var(--md-color-attention-error-4); /* This token was renamed from --md-color-attention-error-surface-active to --md-color-error-surface-active, but the old token is still available for backwards compatibility. It should be removed in a future major release. */
   --md-color-attention-error-surface-active: var(--md-color-attention-error-4);
   --md-color-attention-error-border: var(--md-color-attention-error-6);
 

--- a/packages/css/src/tokens/tokens.css
+++ b/packages/css/src/tokens/tokens.css
@@ -31,9 +31,8 @@
   --md-color-attention-error-surface: var(--md-color-attention-error-1);
   --md-color-attention-error-surface-tinted: var(--md-color-attention-error-2);
   --md-color-attention-error-surface-hover: var(--md-color-attention-error-3);
-  /* Alias: --md-color-attention-error-surface-active (deprecated; remove in a future major release) */
   --md-color-error-surface-active: var(--md-color-attention-error-4);
-  --md-color-attention-error-surface-active: var(--md-color-error-surface-active);
+  --md-color-attention-error-surface-active: var(--md-color-error-surface-active); /* @deprecated: use --md-color-error-surface-active instead */
   --md-color-attention-error-border: var(--md-color-attention-error-6);
 
   --md-color-attention-warning-primary: var(--md-color-attention-warning-6);

--- a/packages/css/src/tokens/tokens.css
+++ b/packages/css/src/tokens/tokens.css
@@ -31,8 +31,9 @@
   --md-color-attention-error-surface: var(--md-color-attention-error-1);
   --md-color-attention-error-surface-tinted: var(--md-color-attention-error-2);
   --md-color-attention-error-surface-hover: var(--md-color-attention-error-3);
-  --md-color-error-surface-active: var(--md-color-attention-error-4); /* This token was renamed from --md-color-attention-error-surface-active to --md-color-error-surface-active, but the old token is still available for backwards compatibility. It should be removed in a future major release. */
-  --md-color-attention-error-surface-active: var(--md-color-attention-error-4);
+  /* Alias: --md-color-attention-error-surface-active (deprecated; remove in a future major release) */
+  --md-color-error-surface-active: var(--md-color-attention-error-4);
+  --md-color-attention-error-surface-active: var(--md-color-error-surface-active);
   --md-color-attention-error-border: var(--md-color-attention-error-6);
 
   --md-color-attention-warning-primary: var(--md-color-attention-warning-6);

--- a/stories/Colors/Tokens.mdx
+++ b/stories/Colors/Tokens.mdx
@@ -63,7 +63,7 @@ These tokens use variables defined in the [Colors section](/docs/introduction-co
 <Token token="--md-color-attention-error-surface-tinted" variable="var(--md-color-attention-error-2)" />
 <Token token="--md-color-attention-error-surface-hover" variable="var(--md-color-attention-error-3)" />
 <Token token="--md-color-error-surface-active" variable="var(--md-color-attention-error-4)" />
-<Token token="--md-color-attention-error-surface-active" variable="var(--md-color-attention-error-4)" />
+<Token token="--md-color-attention-error-surface-active" variable="var(--md-color-error-surface-active)" />
 <Token token="--md-color-attention-error-border" variable="var(--md-color-attention-error-6)" />
 
 ##### Warning

--- a/stories/Colors/Tokens.mdx
+++ b/stories/Colors/Tokens.mdx
@@ -62,7 +62,7 @@ These tokens use variables defined in the [Colors section](/docs/introduction-co
 <Token token="--md-color-attention-error-surface" variable="var(--md-color-attention-error-1)" />
 <Token token="--md-color-attention-error-surface-tinted" variable="var(--md-color-attention-error-2)" />
 <Token token="--md-color-attention-error-surface-hover" variable="var(--md-color-attention-error-3)" />
-<Token token="--md-color-error-surface-active" variable="var(--md-color-error-surface-active)" />
+<Token token="--md-color-attention-error-surface-active" variable="var(--md-color-attention-error-4)" />
 <Token token="--md-color-attention-error-border" variable="var(--md-color-attention-error-6)" />
 
 ##### Warning

--- a/stories/Colors/Tokens.mdx
+++ b/stories/Colors/Tokens.mdx
@@ -62,6 +62,7 @@ These tokens use variables defined in the [Colors section](/docs/introduction-co
 <Token token="--md-color-attention-error-surface" variable="var(--md-color-attention-error-1)" />
 <Token token="--md-color-attention-error-surface-tinted" variable="var(--md-color-attention-error-2)" />
 <Token token="--md-color-attention-error-surface-hover" variable="var(--md-color-attention-error-3)" />
+<Token token="--md-color-error-surface-active" variable="var(--md-color-attention-error-4)" />
 <Token token="--md-color-attention-error-surface-active" variable="var(--md-color-attention-error-4)" />
 <Token token="--md-color-attention-error-border" variable="var(--md-color-attention-error-6)" />
 


### PR DESCRIPTION
# Describe your changes

Introduces `--md-color-error-surface-active` as the new canonical token name. The old `--md-color-attention-error-surface-active` is retained for backward compatibility and now aliases the new token (rather than duplicating the underlying value), so both names always resolve identically. Updates the token documentation to list both the new and the deprecated token name.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [x] If applicable: Is story created/updated in `stories`-folder?
- [ ] If applicable: Is README-file for CSS documentation created/updated?
- [ ] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?