### PR TITLE
Vertical tabs

### DIFF
--- a/packages/css/src/tabs/README.md
+++ b/packages/css/src/tabs/README.md
@@ -7,7 +7,7 @@ Class names in brackets [] are optional-/togglable-/decorator- or state dependan
 See [Storybook](https://miljodir.github.io/md-components) for examples and more info.
 
 ```html
-<div class="md-tabs-container [md-tabs__compact]">
+<div class="md-tabs-container [md-tabs__compact] [md-tabs__vertical]">
   <ul>
     <li>
       <button

--- a/packages/css/src/tabs/tabs.css
+++ b/packages/css/src/tabs/tabs.css
@@ -166,3 +166,38 @@
   flex: 1;
   padding: var(--md-size-12) var(--md-size-24);
 }
+
+/* VERTICAL + COMPACT combined */
+.md-tabs-container.md-tabs__vertical.md-tabs__compact .md-tabs-list .md-tabs-button {
+  /* Restore full border (undo vertical's border-only-right approach) */
+  border: 0.0625rem solid var(--md-color-border-primary);
+  border-radius: 0;
+}
+
+/* Collapse borders between stacked buttons */
+.md-tabs-container.md-tabs__vertical.md-tabs__compact .md-tabs-list .md-tabs-button:not(:first-child) {
+  border-top: none;
+}
+
+/* First button: top corners rounded; undo compact's horizontal border-right:none */
+.md-tabs-container.md-tabs__vertical.md-tabs__compact .md-tabs-list .md-tabs-button:first-child {
+  border-top-left-radius: var(--md-size-4);
+  border-top-right-radius: var(--md-size-4);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 0.0625rem solid var(--md-color-border-primary);
+}
+
+/* Last button: bottom corners rounded; undo compact's horizontal border-left:none */
+.md-tabs-container.md-tabs__vertical.md-tabs__compact .md-tabs-list .md-tabs-button:last-child {
+  border-bottom-left-radius: var(--md-size-4);
+  border-bottom-right-radius: var(--md-size-4);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-left: 0.0625rem solid var(--md-color-border-primary);
+}
+
+/* Active state: use compact's blue-bg, not vertical's thick right border */
+.md-tabs-container.md-tabs__vertical.md-tabs__compact .md-tabs-button.md-tabs-button[aria-selected='true'] {
+  border-right: 0.0625rem solid var(--md-color-cta-primary-focus);
+}

--- a/packages/css/src/tabs/tabs.css
+++ b/packages/css/src/tabs/tabs.css
@@ -125,3 +125,44 @@
 .md-tabs-container.md-tabs__compact .md-tabs-button::after {
   display: none;
 }
+
+/* VERTICAL TABS */
+.md-tabs-container.md-tabs__vertical {
+  flex-direction: row;
+  align-items: flex-start;
+  height: auto;
+}
+
+.md-tabs-container.md-tabs__vertical .md-tabs-list {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.md-tabs-container.md-tabs__vertical .md-tabs-button {
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  padding: var(--md-size-12) var(--md-size-24);
+  border-bottom: none;
+  border-right: var(--md-size-1) solid var(--md-color-border-primary);
+  width: 100%;
+  text-align: left;
+}
+
+.md-tabs-container.md-tabs__vertical .md-tabs-button::after {
+  display: none;
+}
+
+.md-tabs-container.md-tabs__vertical .md-tabs-button.md-tabs-button[aria-selected='true'] {
+  padding: var(--md-size-12) var(--md-size-24);
+  border-bottom: none;
+  border-right: 4px solid var(--md-color-cta-primary-focus);
+}
+
+.md-tabs-container.md-tabs__vertical .md-tabs-panels {
+  flex: 1;
+  padding: var(--md-size-12) var(--md-size-24);
+}

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -36,7 +36,7 @@ export const MdTabs: React.FunctionComponent<MdTabsProps> = ({
 
   return (
     <div className={containerClass}>
-      <Ariakit.TabProvider defaultSelectedId={`md-tab-${selectedTab}`} selectOnMove={false}>
+      <Ariakit.TabProvider defaultSelectedId={`md-tab-${selectedTab}`} selectOnMove={false} orientation={vertical ? 'vertical' : 'horizontal'}>
         <Ariakit.TabList className="md-tabs-list">
           {tabs.map((item, index) => {
             return (

--- a/packages/react/src/tabs/MdTabs.tsx
+++ b/packages/react/src/tabs/MdTabs.tsx
@@ -12,6 +12,7 @@ export interface MdTabsProps {
   chips?: boolean;
   chipsPrefixIcon?: ReactNode;
   compact?: boolean;
+  vertical?: boolean;
 }
 
 export const MdTabs: React.FunctionComponent<MdTabsProps> = ({
@@ -20,12 +21,21 @@ export const MdTabs: React.FunctionComponent<MdTabsProps> = ({
   chips = false,
   chipsPrefixIcon = false,
   compact = false,
+  vertical = false,
 }: MdTabsProps) => {
   const tabs = React.Children.toArray(children).filter(React.isValidElement) as React.ReactElement<MdTabProps>[];
   const selectedTab = initialTab > tabs.length - 1 || initialTab < 0 ? 0 : initialTab;
 
+  const containerClass = [
+    'md-tabs-container',
+    compact ? 'md-tabs__compact' : '',
+    vertical ? 'md-tabs__vertical' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className={`md-tabs-container${compact ? ' md-tabs__compact' : ''}`}>
+    <div className={containerClass}>
       <Ariakit.TabProvider defaultSelectedId={`md-tab-${selectedTab}`} selectOnMove={false}>
         <Ariakit.TabList className="md-tabs-list">
           {tabs.map((item, index) => {

--- a/packages/react/src/tabs/tests/MdTabs.test.tsx
+++ b/packages/react/src/tabs/tests/MdTabs.test.tsx
@@ -107,6 +107,16 @@ describe('MdTabs', () => {
       expect(container.querySelector('.md-tabs__vertical')).not.toBeInTheDocument();
     });
 
+    it('sets aria-orientation to vertical on tablist when vertical prop is passed', () => {
+      render(
+        <MdTabs vertical>
+          <MdTab title="Tab 1">Content</MdTab>
+          <MdTab title="Tab 2">Content 2</MdTab>
+        </MdTabs>,
+      );
+      expect(screen.getByRole('tablist')).toHaveAttribute('aria-orientation', 'vertical');
+    });
+
     it('still renders tabs and content in vertical mode', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/react/src/tabs/tests/MdTabs.test.tsx
+++ b/packages/react/src/tabs/tests/MdTabs.test.tsx
@@ -86,6 +86,45 @@ describe('MdTabs', () => {
     });
   });
 
+  describe('vertical mode', () => {
+    it('applies vertical class when vertical is true', () => {
+      const { container } = render(
+        <MdTabs vertical>
+          <MdTab title="Tab 1">Content</MdTab>
+          <MdTab title="Tab 2">Content 2</MdTab>
+        </MdTabs>,
+      );
+      expect(container.querySelector('.md-tabs__vertical')).toBeInTheDocument();
+    });
+
+    it('does not apply vertical class by default', () => {
+      const { container } = render(
+        <MdTabs>
+          <MdTab title="Tab 1">Content</MdTab>
+          <MdTab title="Tab 2">Content 2</MdTab>
+        </MdTabs>,
+      );
+      expect(container.querySelector('.md-tabs__vertical')).not.toBeInTheDocument();
+    });
+
+    it('still renders tabs and content in vertical mode', async () => {
+      const user = userEvent.setup();
+      render(
+        <MdTabs vertical>
+          <MdTab title="Tab 1">First content</MdTab>
+          <MdTab title="Tab 2">Second content</MdTab>
+        </MdTabs>,
+      );
+
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+
+      const secondTab = screen.getByRole('tab', { name: /Tab 2/i });
+      await user.click(secondTab);
+      expect(secondTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
   describe('interactions', () => {
     it('switches content when clicking different tab', async () => {
       const user = userEvent.setup();

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -96,6 +96,17 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    vertical: {
+      type: { name: 'boolean' },
+      description: 'Render tabs vertically, with the tab list on the left and content to the right.',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -106,6 +117,7 @@ const Template = (args: Args) => {
       chips={args.chips}
       chipsPrefixIcon={args.chipsPrefixIcon ? <MdIconCheck /> : null}
       compact={args.compact}
+      vertical={args.vertical}
     >
       <MdTab title="Tab 1">
         <div style={{ fontSize: '20px', marginBottom: '.5em' }}>This is the first tab</div>
@@ -134,4 +146,5 @@ Tabs.args = {
   chips: false,
   chipsPrefixIcon: false,
   compact: false,
+  vertical: false,
 };


### PR DESCRIPTION
# Add vertical orientation support to MdTabs

## Summary

- Added a `vertical` boolean prop to `MdTabs` that stacks the tab list on the left with panel content to the right. The Ariakit `TabProvider` receives `orientation="vertical"` when the prop is set, enabling correct keyboard navigation (`ArrowUp`/`ArrowDown` instead of left/right).

- Added CSS for `.md-tabs__vertical`: the container switches to `flex-direction: row`, buttons render with a right-side border indicator for the active state instead of the bottom underline, and the panel area takes up remaining space.

- Added CSS rules for the combined `.md-tabs__vertical.md-tabs__compact` case, restoring full surrounding borders on buttons, collapsing shared borders between stacked buttons, and rounding only the first/last button's outer corners.

- Updated the README snippet for the CSS package to document `md-tabs__vertical` as an optional modifier class on the container.

- Added a `vertical` control to `Tabs.stories.tsx` and four new tests covering: class application, absence by default, `aria-orientation` attribute, and tab switching in vertical mode.

## Checklist before requesting a review

- [v] I have performed a self-review and test of my code
- [ ] I have added label to the PR (`major`, `minor` or `patch`)
- [v] If applicable: Is story created/updated in `stories`-folder?
- [o] If applicable: Is README-file for CSS documentation created/updated?
- [v] If applicable: Are unit tests created/updated for the component?
- [v] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [o] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [o] If new component: Is CSS-file added to `packages/css/index.css`?