### PR TITLE
Improves ComboBox input padding

### DIFF
--- a/packages/css/src/formElements/combobox/combobox.css
+++ b/packages/css/src/formElements/combobox/combobox.css
@@ -26,7 +26,7 @@
   line-height: var(--md-typography-line-height-medium);
   border: 1px solid var(--md-color-border-primary);
   border-radius: var(--md-size-4);
-  padding: 0.6875rem 5rem 0.6875rem 2.5rem;
+  padding: 0.6875rem 6.2rem 0.6875rem 2.5rem;
 }
 
 .md-combobox--large .md-combobox__input {

--- a/packages/react/src/formElements/MdComboBox.tsx
+++ b/packages/react/src/formElements/MdComboBox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as Ariakit from '@ariakit/react';
-import React, { useMemo, useState, useId, useTransition, useEffect, useCallback } from 'react';
+import React, { useMemo, useState, useId, useTransition, useEffect, useCallback, useRef } from 'react';
 import MdHelpButton from '../help/MdHelpButton';
 import MdHelpText from '../help/MdHelpText';
 import MdIconClose from '../icons-material/MdIconClose';
@@ -91,6 +91,8 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
     const [helpOpen, setHelpOpen] = useState(false);
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [pendingSearchClear, setPendingSearchClear] = useState(false);
+    const [afterWidth, setAfterWidth] = useState(0);
+    const afterRef = useRef<HTMLDivElement>(null);
     const store = Ariakit.useComboboxStore();
 
     const defaultLabels: Required<Labels> = {
@@ -106,6 +108,16 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
         setSearchValue('');
       }
     }, [value]);
+
+    useEffect(() => {
+      const el = afterRef.current;
+      if (!el) return;
+      const observer = new ResizeObserver(() => {
+        setAfterWidth(el.offsetWidth);
+      });
+      observer.observe(el);
+      return () => { observer.disconnect(); };
+    }, []);
 
     useEffect(() => {
       if (!pendingSearchClear) return;
@@ -258,9 +270,10 @@ const MdComboBox = React.forwardRef<HTMLInputElement, MdComboBoxProps>(
               disabled={disabled}
               aria-describedby={ariaDescribedBy}
               value={searchValue}
+              style={{ paddingRight: afterWidth > 0 ? `${afterWidth + 12}px` : undefined }}
               {...otherProps}
             />
-            <div className="md-combobox__input--after">
+            <div ref={afterRef} className="md-combobox__input--after">
               <div>{isMultiSelect && selectedValues.length > 0 && `+${selectedValues.length}`}</div>
               {allowReset && (selectedValues.length > 0 || searchValue !== '') && (
                 <button

--- a/packages/react/src/formElements/tests/MdComboBox.test.tsx
+++ b/packages/react/src/formElements/tests/MdComboBox.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import MdComboBox from '../MdComboBox';
 
 const mockOptions = [
@@ -261,6 +261,65 @@ describe('MdComboBox', () => {
         <MdComboBox id="custom-combobox" options={mockOptions} value="" onSelectOption={() => {}} />,
       );
       expect(container.querySelector('[id^="custom-combobox"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('dynamic padding (ResizeObserver)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('attaches ResizeObserver to the after section on mount', () => {
+      const observeMock = vi.fn();
+      vi.stubGlobal(
+        'ResizeObserver',
+        vi.fn().mockImplementation(() => ({ observe: observeMock, disconnect: vi.fn() })),
+      );
+
+      const { container } = render(<MdComboBox options={mockOptions} value="" onSelectOption={() => {}} />);
+      const afterDiv = container.querySelector('.md-combobox__input--after');
+      expect(observeMock).toHaveBeenCalledWith(afterDiv);
+    });
+
+    it('sets input padding-right to afterWidth + 12px when ResizeObserver fires', async () => {
+      vi.stubGlobal(
+        'ResizeObserver',
+        vi.fn().mockImplementation((cb: ResizeObserverCallback) => ({
+          observe: vi.fn().mockImplementation((el: Element) => {
+            Object.defineProperty(el, 'offsetWidth', { value: 68, configurable: true });
+            cb([], {} as ResizeObserver);
+          }),
+          disconnect: vi.fn(),
+        })),
+      );
+
+      render(<MdComboBox options={mockOptions} value="opt1" onSelectOption={() => {}} allowReset />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('combobox')).toHaveStyle('padding-right: 80px');
+      });
+    });
+
+    it('does not apply inline padding-right before ResizeObserver fires', () => {
+      vi.stubGlobal(
+        'ResizeObserver',
+        vi.fn().mockImplementation(() => ({ observe: vi.fn(), disconnect: vi.fn() })),
+      );
+
+      render(<MdComboBox options={mockOptions} value="" onSelectOption={() => {}} />);
+      expect((screen.getByRole('combobox') as HTMLElement).style.paddingRight).toBe('');
+    });
+
+    it('disconnects ResizeObserver on unmount', () => {
+      const disconnectMock = vi.fn();
+      vi.stubGlobal(
+        'ResizeObserver',
+        vi.fn().mockImplementation(() => ({ observe: vi.fn(), disconnect: disconnectMock })),
+      );
+
+      const { unmount } = render(<MdComboBox options={mockOptions} value="" onSelectOption={() => {}} />);
+      unmount();
+      expect(disconnectMock).toHaveBeenCalled();
     });
   });
 });

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -9,6 +9,13 @@ afterEach(() => {
   cleanup();
 });
 
+// ResizeObserver is not available in jsdom
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // Suppress specific console warnings that come from Ariakit internal async updates
 // These are false positives caused by Ariakit's internal state management
 const originalError = console.error;


### PR DESCRIPTION
# Describe your changes

Dynamically measures the width of trailing elements within the combobox input. Applies appropriate right padding to prevent user input from being obscured by elements like the multi-select count or clear button. Includes a baseline adjustment to the combobox input's right padding in CSS.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [ ] If applicable: Is story created/updated in `stories`-folder?
- [ ] If applicable: Is README-file for CSS documentation created/updated?
- [ ] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?