### PR TITLE
Defaults Accordion to rounded corners and simplifies icons

### DIFF
--- a/packages/css/src/accordionitem/accordionitem.css
+++ b/packages/css/src/accordionitem/accordionitem.css
@@ -1,6 +1,7 @@
 .md-accordion-item {
   background-color: var(--md-color-surface-primary);
   border: 1px solid var(--md-color-border-primary);
+  border-radius: var(--md-radius-md);
   color: var(--md-color-text-primary);
   font-family: var(--md-typography-family-body);
   transition: all 0.2s linear;
@@ -30,13 +31,21 @@
 
 .md-accordion-item.md-accordion-item--add {
   background-color: transparent;
-  border: 1px dashed var(--md-color-grey-80);
+  border: 0 none;
+  border-radius: 0;
+  border-top: 1px solid var(--md-color-border-primary);
   transition: all 0.2s linear;
 }
 .md-accordion-item[open].md-accordion-item--add {
   background-color: transparent;
-  border: 1px dashed var(--md-color-grey-80);
+  border: 0 none;
+  border-radius: 0;
+  border-top: 1px solid var(--md-color-border-primary);
   transition: all 0.2s linear;
+}
+
+.md-accordion-item.md-accordion-item--add .md-accordion-item__header-icon{
+  color: var(--md-color-text-secondary);
 }
 
 .md-accordion-item:not([open], .md-accordion-item--disabled):hover {
@@ -93,19 +102,6 @@
 .md-accordion-item[open] > .md-accordion-item__header .md-accordion-item__header-icon {
   transform: rotate(180deg);
 }
-.md-accordion-item > .md-accordion-item__header .md-accordion-item__header-icon__open {
-  display: block;
-}
-.md-accordion-item[open] > .md-accordion-item__header .md-accordion-item__header-icon__open {
-  display: none;
-}
-.md-accordion-item > .md-accordion-item__header .md-accordion-item__header-icon__close {
-  display: none;
-}
-.md-accordion-item[open] > .md-accordion-item__header .md-accordion-item__header-icon__close {
-  display: block;
-}
-
 .md-accordion-item__header-label {
   font-size: var(--md-size-20);
   margin-left: var(--md-size-16);

--- a/packages/react/src/accordion/MdAccordion.tsx
+++ b/packages/react/src/accordion/MdAccordion.tsx
@@ -19,6 +19,9 @@ export const MdAccordion: React.FunctionComponent<MdAccordionProps> = ({
   className = '',
   theme,
   hideCloseButton,
+  /**
+   * v6.30.1 Rounded corners are now the default for all components, and the prop is deprecated. This prop will be removed in a future release.
+   */  
   rounded,
   disabled = false,
   ...otherProps

--- a/packages/react/src/accordion/MdAccordionItem.tsx
+++ b/packages/react/src/accordion/MdAccordionItem.tsx
@@ -2,9 +2,8 @@
 
 import classnames from 'classnames';
 import React, { useEffect, useId } from 'react';
-import MdIconAdd from '../icons-material/MdIconAdd';
+import MdIconKeyboardArrowDown from '../icons-material/MdIconKeyboardArrowDown';
 import MdIconRemove from '../icons-material/MdIconRemove';
-
 export interface MdAccordionItemProps {
   label?: string;
   headerContent?: React.ReactNode | string;
@@ -108,8 +107,7 @@ export const MdAccordionItem: React.FunctionComponent<MdAccordionItemProps> = ({
       <summary className="md-accordion-item__header" tabIndex={disabled ? -1 : undefined} aria-disabled={disabled}>
         <div className="md-accordion-item__header-left">
           <div className="md-accordion-item__header-icon" aria-hidden="true">
-            <MdIconAdd className="md-accordion-item__header-icon__open" />
-            <MdIconRemove className="md-accordion-item__header-icon__close" />
+            <MdIconKeyboardArrowDown />
           </div>
           {label && label !== '' && <div className="md-accordion-item__header-label">{label}</div>}
         </div>

--- a/stories/Accordion.stories.tsx
+++ b/stories/Accordion.stories.tsx
@@ -87,7 +87,7 @@ export default {
     },
     rounded: {
       type: { name: 'boolean' },
-      description: 'Add rounded corners to accordion item',
+      description: 'Deprecated: Rounded corners are now the default for all components, and the prop will be removed in a future release.',
       table: {
         defaultValue: { summary: 'false' },
         type: {
@@ -105,7 +105,6 @@ const Template: StoryFn<typeof MdAccordion> = (args: MdAccordionProps) => {
       name={args.name || 'example-accordion'}
       theme={args.theme}
       hideCloseButton={args.hideCloseButton}
-      rounded={args.rounded}
       disabled={args.disabled}
       style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
     >

--- a/stories/AccordionItem.stories.tsx
+++ b/stories/AccordionItem.stories.tsx
@@ -122,7 +122,7 @@ export default {
     },
     rounded: {
       type: { name: 'boolean' },
-      description: 'Add rounded corners to accordion item',
+      description: 'Deprecated: Rounded corners are now the default for all components, and the prop will be removed in a future release.',
       table: {
         defaultValue: { summary: 'false' },
         type: {
@@ -186,6 +186,5 @@ AccordionItem.args = {
   headerContent: false,
   hideCloseButton: false,
   closeButtonText: 'Lukk',
-  rounded: false,
   id: undefined,
 };


### PR DESCRIPTION
# Describe your changes

Added new rounded corners as default style. Deprecates the `rounded` prop for Accordion and AccordionItem as rounded corners are now applied by default. Refactors the accordion item header to use a single `KeyboardArrowDown` icon, which rotates to indicate open/closed states, replacing the previous `Add` and `Remove` icons. Adjusts the styling of the "add" variant accordion item for a cleaner look, replacing the dashed border with a solid top border.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [x] If applicable: Is story created/updated in `stories`-folder?
- [ ] If applicable: Is README-file for CSS documentation created/updated?
- [ ] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?