### PR TITLE
Adds toggle label position control

### DIFF
--- a/packages/css/src/toggle/toggle.css
+++ b/packages/css/src/toggle/toggle.css
@@ -23,7 +23,17 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  gap: var(--md-size-8);
 }
+
+.md-toggle__label-wrapper--reverse {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: var(--md-size-8);
+  flex-direction: row-reverse;
+}
+
 
 .md-toggle__wrapper:has(:focus-visible) .md-toggle__label-wrapper {
   outline: var(--md-size-3) var(--md-color-focus-outer) solid;
@@ -70,10 +80,6 @@
 .md-toggle__label--disabled {
   background-color: var(--md-color-surface-grey);
   cursor: default;
-}
-
-.md-toggle__label-text {
-  margin-right: var(--md-size-8);
 }
 
 .md-toggle__label .md-toggle__button {

--- a/packages/react/src/toggle/MdToggle.tsx
+++ b/packages/react/src/toggle/MdToggle.tsx
@@ -7,6 +7,7 @@ export interface MdToggleProps extends React.InputHTMLAttributes<HTMLInputElemen
   error?: boolean;
   errorText?: string | undefined;
   wrapperClass?: string;
+  textLeft?: boolean;
 }
 
 export const MdToggle: React.FunctionComponent<MdToggleProps> = ({
@@ -16,6 +17,7 @@ export const MdToggle: React.FunctionComponent<MdToggleProps> = ({
   disabled = false,
   error = false,
   errorText = undefined,
+  textLeft = true,
   wrapperClass = '',
   ...otherProps
 }: MdToggleProps) => {
@@ -30,6 +32,7 @@ export const MdToggle: React.FunctionComponent<MdToggleProps> = ({
 
   const labelWrapperClassNames = classnames('md-toggle__label-wrapper', {
     'md-toggle__label-wrapper--disabled': !!disabled,
+    'md-toggle__label-wrapper--reverse': !textLeft,
   });
 
   const outerWrapperClassNames = classnames('md-toggle__wrapper', wrapperClass);

--- a/stories/Toggle.stories.tsx
+++ b/stories/Toggle.stories.tsx
@@ -63,6 +63,26 @@ export default {
       },
       control: { type: 'text' },
     },
+    textLeft: {
+      description: 'Toggle label is on the left or right side of the toggle button',
+      table: {
+        defaultValue: { summary: 'true' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    error: {
+      description: 'Does toggle contain an error?',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: {
+          summary: 'boolean',
+        },
+      },
+      control: { type: 'boolean' },
+    },    
     disabled: {
       description: 'Is the toggle disabled?',
       table: {
@@ -119,6 +139,7 @@ const Template = (args: MdToggleProps) => {
 export const Toggle = Template.bind({});
 Toggle.args = {
   label: 'Label',
+  textLeft: true,
   checked: false,
   disabled: false,
   error: false,


### PR DESCRIPTION
# Describe your changes

Introduces a `textLeft` prop to the `MdToggle` component, enabling users to control whether the label text appears to the left or right of the toggle button.

This functionality is implemented by applying a new CSS modifier class that utilizes `flex-direction: row-reverse` on the label wrapper. Spacing between the label and button is now consistently managed via `gap` on the wrapper, standardizing layout and removing individual margin rules.

Updates Storybook to expose and document the new prop.

## Checklist before requesting a review

- [x] I have performed a self-review and test of my code
- [x] I have added label to the PR (`major`, `minor` or `patch`)
- [x] If applicable: Is story created/updated in `stories`-folder?
- [ ] If applicable: Is README-file for CSS documentation created/updated?
- [ ] If applicable: Are unit tests created/updated for the component?
- [ ] If applicable: Tested in Storybook with keyboard, screen reader, zoom, and color contrast
- [ ] If new component: Is tsx-file import added to `packages/react/index.tsx`?
- [ ] If new component: Is CSS-file added to `packages/css/index.css`?